### PR TITLE
Add production TODO with ChatGPT prompts

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,49 @@
+# Endless Escape Production TODO
+
+This checklist breaks the roadmap into actionable milestones with ready-to-use ChatGPT prompts for each task. Share the relevant prompt with ChatGPT (or tailor it) to receive detailed guidance, drafts, or assets.
+
+## Phase 1: Pre-Production (2 weeks)
+- [ ] **Finalize satirical script and tone bible**  
+  Prompt: "You are a satirical narrative designer. Help me expand the tone bible for a comedic endless runner inspired by Viktor Orbán, covering themes, dos/don'ts, and sample jokes that stay playful without being defamatory."
+- [ ] **Storyboard opening cinematic**  
+  Prompt: "Act as a cinematics director. Outline a 10-panel storyboard for the opening escape sequence of a satirical endless runner, including camera notes, action beats, and caption ideas."
+- [ ] **Prototype core feel in Godot**  
+  Prompt: "Pretend you are a senior Godot engineer. Provide step-by-step instructions and sample GDScript for prototyping an endless runner movement prototype (run, jump, slide) using Godot 4."
+- [ ] **Define art direction guide**  
+  Prompt: "You are an indie art lead. Draft a pixel-art style guide for caricatured political satire characters, listing palette suggestions, silhouette rules, and animation principles."
+
+## Phase 2: Vertical Slice (6 weeks)
+- [ ] **Core runner mechanics implementation**  
+  Prompt: "Serve as a gameplay programmer. Detail the Godot node structure and GDScript snippets for an endless runner with parallax backgrounds, obstacle spawning, and difficulty scaling."
+- [ ] **Design 3 modular city tilesets**  
+  Prompt: "Take the role of a level designer. Describe three modular city block concepts (Charity Strip, Media Alley, Border Fence) with hazard lists, art callouts, and gameplay beats."
+- [ ] **Create 4 power-up systems**  
+  Prompt: "Act as a systems designer. Break down four humorous power-ups (Public Works Jetpack, Friends-and-Family Motorcade, Nationalized Media Megaphone, Mystery slot) including mechanics, duration, and balancing notes."
+- [ ] **Develop one "scandal season" event**  
+  Prompt: "Imagine you are a live-ops designer. Pitch a 1-week seasonal modifier for the endless runner that riffs on a fictional corruption leak, including gameplay twists, rewards, and narrative flavor."
+
+## Phase 3: Content Expansion (8 weeks)
+- [ ] **Build Safehouse meta-progression**  
+  Prompt: "Play the role of a UX/game designer. Outline the Safehouse base-building loop with room unlocks, upgrade costs, UI flow, and narrative snippets."
+- [ ] **Implement underground bonus level**  
+  Prompt: "You are a level scripter. Provide a step-by-step plan and GDScript hooks for a timed underground metro bonus stage focused on collecting shredded documents."
+- [ ] **Polish UI/UX and accessibility**  
+  Prompt: "Act as a UI/UX consultant. Suggest UI layouts, HUD readability tweaks, colorblind-safe palettes, and haptic/feedback ideas for a satirical endless runner."
+- [ ] **Integrate backend leaderboards**  
+  Prompt: "Pretend to be a backend engineer. Explain how to connect a Godot WebGL/mobile build to a serverless leaderboard using Cloudflare Workers and FaunaDB, with API endpoints and data schemas."
+
+## Phase 4: Launch Preparation (4 weeks)
+- [ ] **Cross-platform QA plan**  
+  Prompt: "Assume you are a QA lead. Draft a comprehensive test plan covering WebGL, iOS, and Android builds, focusing on performance, input responsiveness, and satire-sensitive content checks."
+- [ ] **Compliance & localization review**  
+  Prompt: "Be a compliance specialist. List key legal/distribution checks (app store, satire disclaimers, privacy policies) and localization considerations for global release."
+- [ ] **Deploy marketing microsite**  
+  Prompt: "Act as a web marketer. Outline a static microsite structure that teases the game, includes a satire disclaimer, captures mailing list signups, and embeds a WebGL demo."
+
+## Ongoing / Supporting Tasks
+- [ ] **Audio direction & SFX brief**  
+  Prompt: "You are an audio director. Create a brief for Balkan-electro chase music and slapstick SFX that reinforce comedic tension in an endless runner."
+- [ ] **Narrative collectible design**  
+  Prompt: "Imagine you are a narrative designer. Generate a list of collectible 'leaked memo' concepts with unlock conditions and lore snippets that stay tongue-in-cheek."
+- [ ] **Community & leaderboard events calendar**  
+  Prompt: "Serve as a community manager. Plan a 3-month calendar of rotating scandal seasons, social media beats, and leaderboard spotlights." 


### PR DESCRIPTION
## Summary
- add a todo checklist that mirrors the roadmap milestones
- provide ready-to-use ChatGPT prompts for each milestone and supporting task

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbd5b31318832fa8100e18b4650487