### PR TITLE
Add pre-production script, storyboard, and Godot prototype plan

### DIFF
--- a/docs/preproduction/godot_vertical_slice_prototype.md
+++ b/docs/preproduction/godot_vertical_slice_prototype.md
@@ -1,0 +1,132 @@
+# Godot Prototype Plan – Core Feel Vertical Slice
+
+This document describes the moment-to-moment gameplay prototype required to validate tone, pacing, and mechanics for the "Endless Escape" vertical slice.
+
+## Prototype Goals
+1. **Establish Cartoon Chase Momentum** – Responsive run/jump/slide loop with comedic FX hooks.
+2. **Demonstrate Escalating Pressure** – Simple heat meter that spawns additional pursuers.
+3. **Inject Satirical Flavor** – Contextual barks, UI callouts, and prop gags triggered by player actions.
+
+## Scene Structure
+```
+MainScene (Node2D)
+├── World (Node2D)
+│   ├── ParallaxBackground (ParallaxBackground)
+│   │   ├── LayerSky (ParallaxLayer -> Sprite2D)
+│   │   └── LayerCity (ParallaxLayer -> Sprite2D)
+│   ├── Ground (StaticBody2D + CollisionShape2D)
+│   ├── ObstacleSpawner (Node)
+│   ├── PickupSpawner (Node)
+│   ├── PursuitDirector (Node)
+│   └── Vic (CharacterBody2D)
+│       ├── AnimatedSprite2D
+│       └── DustTrail (GPUParticles2D)
+├── UI (CanvasLayer)
+│   ├── HeatMeter (TextureProgressBar)
+│   ├── PromptLabel (RichTextLabel)
+│   ├── PowerupTimer (Label)
+│   └── CaptionFeed (VBoxContainer)
+└── AudioBus (Node)
+    ├── Music (AudioStreamPlayer)
+    └── SFX (AudioStreamPlayer2D)
+```
+
+## Implementation Steps
+1. **Character Controller**
+   - Add `Vic` as `CharacterBody2D` with capsule collider and `AnimatedSprite2D` states (`run`, `jump`, `slide`, `jetpack`).
+   - Configure gravity (1800 px/s²), run speed (320 px/s), jump impulse (600 px/s), slide duration (0.4 s).
+   - Hook input actions: `ui_accept` (jump), `slide` (swipe/down arrow), `powerup` (tap & hold).
+
+2. **Lane Management**
+   - Use invisible markers to lock the player to ground plane while allowing vertical arcs.
+   - Add `CoyoteTimer` to permit jump input within 0.1s after leaving ground for forgiving controls.
+
+3. **Obstacle & Pickup Systems**
+   - `ObstacleSpawner` instantiates pre-authored scenes (e.g., `CaviarTray.tscn`, `Limousine.tscn`) every 1.5–3 seconds based on heat level.
+   - `PickupSpawner` emits `SpinTape` and `ConsultancyCoin` nodes using weighted randomness; align them with safe lanes.
+   - Add `Area2D` triggers on obstacles/pickups to play VO quips when first encountered.
+
+4. **Heat Meter & Pursuit Director**
+   - Heat increases by +1 per second and +5 per obstacle hit; decreases by -10 when picking up `SpinTape`.
+   - At thresholds (25/50/75) the `PursuitDirector` spawns drones, limos, and helicopter spotlight overlays respectively.
+   - Each spawn triggers a bark from Agent Hilda via `CaptionFeed` (scrolling headline UI).
+
+5. **Tone Delivery**
+   - Implement `CaptionFeed` as a queue of two-line jokes pulled from JSON to ensure repeatable style testing.
+   - Trigger dust trails and money particle effects during slides and power-up activation.
+   - Sync protest chants to beat markers in `Music` player (use `AudioStreamPlayback` callbacks).
+
+6. **Camera & Parallax**
+   - Parent `Camera2D` to `Vic` with dampening (0.1) and custom screen shake on obstacle impacts.
+   - Parallax background uses 3 speeds (sky 0.2x, city 0.5x, foreground signage 0.8x) for depth.
+
+7. **Moment-to-Moment Loop**
+   - Tutorial prompts appear via `PromptLabel` with timers that fade out once the player performs each action.
+   - After 90 seconds, enable procedural segment randomization using a queue of chunk scenes.
+
+## Sample GDScript – Vic Controller
+```gdscript
+extends CharacterBody2D
+
+@export var run_speed: float = 320.0
+@export var jump_velocity: float = -600.0
+@export var slide_duration: float = 0.4
+@export var gravity: float = 1800.0
+
+var _slide_timer := 0.0
+var _coyote_timer := 0.0
+var _is_sliding := false
+
+func _physics_process(delta: float) -> void:
+    if not is_on_floor():
+        velocity.y += gravity * delta
+    else:
+        velocity.y = max(velocity.y, 0.0)
+        _coyote_timer = min(_coyote_timer + delta, 0.1)
+
+    velocity.x = run_speed
+
+    _handle_jump(delta)
+    _handle_slide(delta)
+
+    move_and_slide()
+    _update_animation()
+
+func _handle_jump(delta: float) -> void:
+    if Input.is_action_just_pressed("ui_accept") and (_coyote_timer > 0.0 or is_on_floor()):
+        velocity.y = jump_velocity
+        _coyote_timer = 0.0
+        $AnimatedSprite2D.play("jump")
+        get_tree().call_group("vo", "play_quip", "jump")
+    elif is_on_floor():
+        _coyote_timer = 0.1
+
+func _handle_slide(delta: float) -> void:
+    if Input.is_action_just_pressed("slide") and is_on_floor() and not _is_sliding:
+        _is_sliding = true
+        _slide_timer = slide_duration
+        $AnimatedSprite2D.play("slide")
+        $CollisionShape2D.scale.y = 0.6
+        get_tree().call_group("sfx", "emit_slide")
+    if _is_sliding:
+        _slide_timer -= delta
+        if _slide_timer <= 0.0:
+            _is_sliding = false
+            $CollisionShape2D.scale.y = 1.0
+            $AnimatedSprite2D.play("run")
+
+func _update_animation() -> void:
+    if is_on_floor() and not _is_sliding:
+        $AnimatedSprite2D.play("run")
+```
+
+## Satirical Feedback Hooks
+- **VO Manager:** Autoload singleton (`VoDirector.gd`) that sequences narrator, Hilda, and protest chants; ensures quip cooldown (min 6s between lines).
+- **Headline Pop-ups:** On major events (heat thresholds, crashes), spawn floating UI cards with tabloid-style headlines to reinforce tone.
+- **Dynamic Music Stems:** Blend in brass stabs when heat > 50; reduce percussion when player activates megaphone power-up.
+
+## Prototype Milestones
+1. **Day 1–2:** Build scene skeleton, movement controller, placeholder sprites.
+2. **Day 3–4:** Implement spawners, heat logic, UI prompts.
+3. **Day 5:** Layer satire systems (VO, captions), tighten juice (particles, screen shake).
+4. **Day 6:** Playtest for readability, adjust pacing, capture vertical slice footage.

--- a/docs/preproduction/opening_storyboard.md
+++ b/docs/preproduction/opening_storyboard.md
@@ -1,0 +1,26 @@
+# Opening Cinematic Storyboard – "Audit Alarm"
+
+| Panel | Camera & Framing | Action Beat | FX & UI Notes | Caption / Dialogue |
+| --- | --- | --- | --- | --- |
+| 1 | **Slow push-in** on dim tunnel, Dutch angle to suggest imbalance. | Vic peers through cracked locker door, stage lights flicker. | Flickering neon sign “Charity Match – Sponsored by Transparency LLC.” Ambient crowd cheer fading. | Narrator (VO): “Tonight’s charity match raised eyebrows—and offshore interest rates.” |
+| 2 | **Medium close-up** with handheld wobble. | Vic snaps briefcase shut; bundles stamped “Infrastructure Grant” pop out. | Cartoon cash burst; overlay prompt: **Tap to stash**. | Vic: “Note to self: invest in better rubber bands.” |
+| 3 | **Insert shot** of champagne cork ricocheting toward massive red button. | Cork slams “AUDIT” alarm; sprinkler rains confetti-shaped subpoenas. | Alarm SFX crossfades into rhythmic beat matching soundtrack. | PA: “Emergency! Transparency protocols breached!” |
+| 4 | **Hero shot** from low angle. | Agent Hilda descends on retractable podium flanked by drones projecting searchlights. | Drones trail blue-and-gold strobe reminiscent of EU flag. | Hilda: “Operation Photo-Op is a go. Remember, smiles wide for the press!” |
+| 5 | **Whip pan** tracking left. | Vic vaults over donation boxes, lands on scooter labeled “Infrastructure Pilot.” | Motion lines emphasize speed; UI flashes **Swipe Up to Jump**. | Narrator: “Public spending meets private getaway.” |
+| 6 | **Side-scrolling mockup** (2.5D). | Garage door slams; Vic slides under, sparks shower from metal grate. | Parallax layers preview city chase environment. | Béla (VO): “Mind the tuxedo queue, sir!” |
+| 7 | **Wide aerial** establishing rooftop path. | Vic launches via fireworks that spell “Re-Election Tour.” Protest crowd spills into street below. | Fireworks timed to beat drop; HUD heat meter flickers to life. | Crowd Chant SFX: “Hey hey! Ho ho! Where’d the stadium budget go?” |
+| 8 | **Freeze-frame** with anamorphic squeeze. | UI overlay displays three alibi choices with caricature icons. | Tooltip describing first-run bonus. | Vic: “Can’t spell ‘plausible’ without ‘possible’!” |
+| 9 | **Match cut** to gameplay camera. | Player confirms choice; jetpack sputters to life with receipts as exhaust. | Transition from 24fps cinematic to 60fps gameplay; UI fades in (score, heat meter). | Narrator: “Strap in for tonight’s fiscal fireworks.” |
+| 10 | **Dynamic tracking shot** replicating gameplay FOV. | Agents burst through skylight in background, establishing ongoing chase. | Tutorial prompts animate at screen edges (Swipe, Tap). | Hilda (VO): “Team, let’s keep the optics on-brand!” |
+
+## Cinematic Rhythm & Timing Notes
+- **Duration:** ~45 seconds before control handoff.
+- **Music:** Balkan-electro track ramps from sly bass groove (panels 1–3) to brassy chase anthem (panels 7–10).
+- **Color Script:** Start with warm interior oranges, shift to cool night-time blues accented with magenta protest signage.
+- **Transition Strategy:** Final panel uses motion blur and UI elements from gameplay to ensure seamless shift into interactive tutorial.
+
+## Production Checklist
+1. **Storyboard Line Art:** Greyscale thumbnails with highlighted props (briefcase, alarm button, drones).
+2. **Animatic:** Rough timing pass matching BPM 110 → 128 to test comedic beats.
+3. **VO Scratch Track:** Record temporary lines for Vic, Hilda, Narrator to validate timing before final casting.
+4. **Integration:** Export storyboard panels into Godot cutscene timeline using AnimationPlayer with signal trigger for gameplay start.

--- a/docs/preproduction/satirical_script.md
+++ b/docs/preproduction/satirical_script.md
@@ -1,0 +1,95 @@
+# "Endless Escape" Satirical Script Draft
+
+## Tone Pillars
+- **Playfully Subversive:** Every line lands as a wink to the camera—outlandish metaphors and exaggerated bureaucracy keep things comedic rather than accusatory.
+- **Cartoon-Calamity Pacing:** Dialogue punctuates slapstick mishaps; no quip lasts long enough to slow the chase.
+- **Lovable Rogues Gallery:** Orbán’s analog and the task-force both relish the absurdity, ensuring satire skewers power structures while letting characters stay charming.
+
+## Cast of Exaggerated Figures
+| Name | Role | Hook |
+| --- | --- | --- |
+| **Viktor “Vic” Orbital** | Player avatar; charismatic schemer | Balancing a briefcase overflowing with “consultancy vouchers.” |
+| **Agent Hilda Hex** | Lead Interpol chaser | Calm, deadpan, wields a megaphone that fires subpoenas like confetti. |
+| **Junior Agent Béla** | Tutorial VO; overeager rookie | Constantly fact-checking with a tablet that glitches with pop-up ads. |
+| **Narrator** | Satirical VO | Breaks the fourth wall to recap alleged scandals as tabloid headlines. |
+| **Protest Chorus** | Crowd SFX | Chant in melodic call-and-response (“Hey hey! Ho ho! Where’d the stadium budget go?”). |
+
+## Opening Cinematic Script (00:45)
+**Panel 1 – Stadium Tunnel**  
+*Visual:* Vic peeks through a cracked locker room door; neon “Charity Match” sign flickers behind him.  
+*VO (Narrator):* “Tonight’s charity match raised eyebrows—and offshore interest rates.”
+
+**Panel 2 – Briefcase Gag**  
+*Action:* Vic slams briefcase shut; bills stamped “Development Grant” spring out like confetti.  
+*Vic (muttering):* “Note to self: diversify into sturdier rubber bands.”
+
+**Panel 3 – Alarm Trigger**  
+*Action:* A champagne cork hits a giant red **AUDIT** button. Sirens blare.  
+*PA System:* “Emergency! Transparency protocols breached!”
+
+**Panel 4 – Agents Assemble**  
+*Visual:* Hilda Hex descends on a retractable podium flanked by drones.  
+*Hilda:* “Operation: Photo Op is a go. Remember, smiles wide for the press!”
+
+**Panel 5 – Escape Beat**  
+*Action:* Vic slides under a half-closed garage door, snatching a scooter labeled “Infrastructure Pilot.”  
+*Narrator:* “And just like that, public spending meets private getaways.”
+
+**Panel 6 – Rooftop Sprint**  
+*Action:* Vic launches onto rooftops as fireworks spell “Re-Election Tour.” Protest Chorus rises.
+
+**Panel 7 – Freeze-Frame Choice**  
+*UI:* Player chooses alibi (options: “Youth Outreach,” “Cultural Exchange,” “Visionary Stadium”). Each affects first power-up.  
+*Vic:* “Can’t spell ‘plausible’ without ‘possible’!”
+
+**Panel 8 – Smash Cut to Gameplay**  
+*Action:* Camera locks into side-scroller perspective. Jetpack sparks.
+
+## Tutorial Moment-to-Moment Script (First 90 Seconds)
+
+### Segment A: Charity Strip (0:00–0:30)
+- **VO (Béla):** “Mr. Orbital! Quick reminder—our drones recommend three-point contact when sliding under donor limos.”
+- **Mechanic Prompts:** Tap to jump over flung caviar trays; swipe down to slide under gold-plated convertibles.
+- **Gag Beats:** VIP donor tosses a bouquet of nondisclosure agreements; catching it grants a shield.
+
+### Segment B: Media Monopoly Alley (0:30–1:00)
+- **VO (Narrator):** “Local stations interrupt your regularly scheduled programming for… you.”
+- **Mechanic Prompts:** Collect “Spin Tape” pickups to activate the **Nationalized Media Megaphone**—projecting a speech bubble vortex that pushes pursuers back.
+- **Chaser Banter:**
+  - *Hilda:* “Deploy the paparazzi drones!”
+  - *Béla:* “Uh, ma’am, they’re livestreaming his mixtape instead.”
+
+### Segment C: Border Fence Sprint (1:00–1:30)
+- **VO (Narrator):** “Who needs borders when you’ve got hurdles of red tape?”
+- **Mechanic Prompts:** Time vaults over retractable fences while dodging spotlight sweeps.
+- **Set-Piece:** Sliding through a customs scanner; machine prints out a receipt for “Cultural Heritage Export.”
+
+## Endless Run Callouts (Post-Tutorial Loop)
+
+### Heat Escalation Barks
+| Heat Level | Audio Cue | Narrative Flavor |
+| --- | --- | --- |
+| **Green** | Protest Chorus sings off-key parody of stadium anthems. | “We just want receipts!”
+| **Yellow** | Hilda switches to megaphone with sparkler siren. | “Authorise the armored limos!”
+| **Red** | Helicopter spotlight shapes into giant EU flag. | “Reminder: Ignoring subpoenas voids frequent flyer miles.”
+
+### Power-Up Quips
+- **Public Works Jetpack:** *Vic:* “If this flies, so does fiscal responsibility!”
+- **Friends-and-Family Motorcade:** *Narrator:* “When nepotism gives you lemons, form a defensive circle.”
+- **Nationalized Media Megaphone:** *Crowd:* “Feedback loop! Feedback loop!”
+
+### Fail States
+- **Caught by Agents:** Freeze-frame Polaroid prints “Local Man Trips Over Transparency.”
+- **Tripped by Protestors:** Chant shifts to lullaby tempo, screen fades to tabloid headline.
+- **Out of Juice:** Jetpack sputters, releasing IOU slips; scoreboard tallies “Favors Owed.”
+
+## Collectible Dossier Vignettes
+1. **Leaked Memo: “Stadium Naming Rights”** – Unlocks banter about selling naming rights to a cousin’s pet.
+2. **Audio Tape: “Media Syndication Strategy”** – Adds remix track where Vic samples his own press conferences.
+3. **Ledger Page: “Consultancy Cruise Itinerary”** – Reveals a background cameo of a yacht-on-wheels cheering section.
+4. **Security Badge: “Contractor of Record”** – Spawns NPC contractor tossing invoices like shuriken.
+
+## Closing Cinematic Tag (Vertical Slice Cliffhanger)
+*Visual:* Vic rockets through a holographic EU Parliament; hologram glitches into “To Be Continued pending investigation.”
+*Hilda (VO):* “He can outrun us, but can he outrun quarterly audits?”
+*Narrator:* “Next time on Endless Escape: budget hearings go ballistic.”

--- a/todo.md
+++ b/todo.md
@@ -3,11 +3,11 @@
 This checklist breaks the roadmap into actionable milestones with ready-to-use ChatGPT prompts for each task. Share the relevant prompt with ChatGPT (or tailor it) to receive detailed guidance, drafts, or assets.
 
 ## Phase 1: Pre-Production (2 weeks)
-- [ ] **Finalize satirical script and tone bible**  
+- [x] **Finalize satirical script and tone bible** – see `docs/preproduction/satirical_script.md`.
   Prompt: "You are a satirical narrative designer. Help me expand the tone bible for a comedic endless runner inspired by Viktor Orbán, covering themes, dos/don'ts, and sample jokes that stay playful without being defamatory."
-- [ ] **Storyboard opening cinematic**  
+- [x] **Storyboard opening cinematic** – see `docs/preproduction/opening_storyboard.md`.
   Prompt: "Act as a cinematics director. Outline a 10-panel storyboard for the opening escape sequence of a satirical endless runner, including camera notes, action beats, and caption ideas."
-- [ ] **Prototype core feel in Godot**  
+- [x] **Prototype core feel in Godot** – see `docs/preproduction/godot_vertical_slice_prototype.md`.
   Prompt: "Pretend you are a senior Godot engineer. Provide step-by-step instructions and sample GDScript for prototyping an endless runner movement prototype (run, jump, slide) using Godot 4."
 - [ ] **Define art direction guide**  
   Prompt: "You are an indie art lead. Draft a pixel-art style guide for caricatured political satire characters, listing palette suggestions, silhouette rules, and animation principles."


### PR DESCRIPTION
## Summary
- add a satirical tone bible and script draft that map out the opening cinematic and tutorial beats
- outline a 10-panel storyboard for the audit alarm opening sequence with timing and production notes
- document a Godot prototype plan covering node structure, mechanics, and sample GDScript to define the vertical slice feel

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cbd8b39a00832fa9cde67bce38be51