### PR TITLE
Add documentation scaffolding for narrative, assets, and backend

### DIFF
--- a/assets/asset_catalog.md
+++ b/assets/asset_catalog.md
@@ -1,0 +1,44 @@
+# Asset Catalog Outline
+
+## Visual Assets
+
+### Characters
+- Hero variants (model sheets, animations, textures).
+- NPC archetypes per faction with costume/prop notes.
+- Enemies with attack VFX/SFX pairing requirements.
+
+### Environments
+- Biomes/levels with mood boards and modular kits.
+- Key landmarks and interactive set pieces.
+- Lighting profiles and skyboxes per time-of-day.
+
+### Props & UI
+- Core interactive props and upgrade items.
+- Satirical signage/posters with localization layers.
+- HUD widgets, icons, and motion graphics.
+
+## Audio Assets
+- Original soundtrack tracks with mood references.
+- Diegetic/ambient loops mapped to environments.
+- SFX libraries (UI, combat, systemic loops) with ownership.
+- VO casting requirements and recording schedule.
+
+## Narrative Assets
+- Script packages per mission (dialogue, branching nodes).
+- Codex/lore entries and unlock triggers.
+- Cinematic storyboards and animatics.
+
+## Technical Specifications
+- Engine target formats (Godot import settings, compression guidelines).
+- Naming conventions and directory structure standards.
+- Version control/LFS requirements for large binaries.
+
+## Production Tracking
+- Source-of-truth tools (Shotgrid, Notion, Google Sheets).
+- Checkpoints for concept, blockout, production-ready, polish.
+- Sign-off workflow and integration testing notes.
+
+## Open Needs & Dependencies
+- Licensing considerations (fonts, stock media, satire references).
+- Outsourcing/vendor briefs.
+- Tooling requests to support asset pipeline.

--- a/backend/schema_planning.md
+++ b/backend/schema_planning.md
@@ -1,0 +1,43 @@
+# Backend Schema Planning Notes
+
+## High-Level Architecture Goals
+- Support cross-platform progression sync for single-player narrative with optional live updates.
+- Provide content telemetry to inform satire effectiveness and pacing adjustments.
+- Ensure mod-friendly data exposure without compromising core saves.
+
+## Core Services & Modules
+- **Authentication**: account linking, anonymous play upgrade path, token refresh cadence.
+- **Player Profile**: progression states, unlocked lore, choices, cosmetics.
+- **Narrative State Machine**: branching decisions, quest flags, timed events.
+- **Economy & Inventory**: currencies, items, crafting components with anti-cheat considerations.
+- **Telemetry & Analytics**: event schema, batching strategy, opt-out handling.
+- **Content Delivery**: hotfix patching, seasonal drops, localization updates.
+
+## Data Model Sketch
+- `players` table: account_id (PK), display_name, platform_links, created_at, last_seen.
+- `save_slots` table: slot_id (PK), account_id (FK), narrative_state JSONB, progression_version.
+- `inventory_items` table: entry_id (PK), slot_id (FK), item_id, quantity, metadata.
+- `quests` table: quest_id (PK), title, description, required_flags, reward_bundle.
+- `quest_progress` table: entry_id (PK), slot_id (FK), quest_id (FK), status enum, last_updated.
+- `telemetry_events` table: event_id (PK), account_id (FK), event_type, payload JSONB, timestamp.
+- `content_packages` table: package_id (PK), version, release_notes, checksum, required_client_version.
+
+## API Considerations
+- REST or GraphQL for client interactions; document endpoints per module.
+- Webhook or message bus for telemetry ingestion into analytics pipeline.
+- Rate limiting policy and pagination guidelines.
+
+## Security & Compliance Notes
+- GDPR/CCPA data retention matrix and deletion workflows.
+- Encryption at rest for sensitive fields, TLS everywhere in transit.
+- Role-based access controls for admin tools and content management.
+
+## Tooling & Workflow
+- Schema migration strategy (e.g., Prisma, Alembic) with rollback plan.
+- Seed data procedures for testing narrative branches.
+- Local development environment requirements (Docker compose services, mock auth).
+
+## Open Questions
+- Offline mode expectations and reconciliation rules when reconnecting.
+- Cross-save support for modded clients.
+- Future multiplayer extension hooks and data partitioning.

--- a/docs/narrative_bible_outline.md
+++ b/docs/narrative_bible_outline.md
@@ -1,0 +1,44 @@
+# Narrative Bible Outline
+
+## Vision Statement
+- High-level summary of the story's themes and intended emotional experience.
+- Elevator pitch capturing the satirical tone and player fantasy.
+
+## World Overview
+- Setting description (time period, geography, socio-political landscape).
+- Core conflicts driving the world and how the player intersects with them.
+- Visual language, motifs, and recurring symbols to reinforce tone.
+
+## Factions & Key Institutions
+- Table of major factions/institutions, their goals, and relationships.
+- Notes on satire targets and how each group reflects them.
+
+## Character Roster
+- Player avatar bio and motivations.
+- Primary cast (allies, rivals, antagonists) with arcs and personality beats.
+- Supporting cast and recurring NPC roles with notes on voice, appearance, and gameplay function.
+
+## Narrative Structure
+- Three-act (or alternative) breakdown with key beats, inciting incident, midpoint, climax, and resolution.
+- Mission/quest progression aligned with story beats.
+- Optional side arcs and how they reinforce core themes.
+
+## Tone & Writing Guidelines
+- Satirical voice principles, dos and don'ts.
+- Sensitivity considerations and satire boundaries.
+- Localization notes for maintaining humor across regions.
+
+## Storytelling Systems Integration
+- How narrative ties into gameplay systems (progression, economy, social mechanics).
+- Branching or reactivity guidelines (critical decisions, fail states, optional flavor).
+- Requirements for dialogue tools, cutscene pipelines, or VO.
+
+## Content Deliverables & Milestones
+- Checklist of narrative deliverables (scripts, barks, codex entries, cinematic briefs).
+- Milestone schedule aligned with production phases.
+- Review cadence and stakeholders for approvals.
+
+## Open Questions & Research Needs
+- Outstanding lore decisions or world-building gaps.
+- Historical/political references to research.
+- Risks or dependencies that could impact story delivery.


### PR DESCRIPTION
## Summary
- create a narrative bible outline to guide story development
- outline the asset catalog structure and production tracking needs
- plan backend schema notes covering services, data model, and open questions

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cbd8d8c838832f99947315ab8d2b15