### PR TITLE
Add coin collectible system to runner world

### DIFF
--- a/game/icon.svg
+++ b/game/icon.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+  <rect width="128" height="128" fill="#1c1f2b"/>
+  <circle cx="64" cy="64" r="52" fill="#ffcc33"/>
+  <path d="M40 88 L64 32 L88 88 Z" fill="#2b2f55"/>
+  <circle cx="64" cy="64" r="12" fill="#ffffff"/>
+</svg>

--- a/game/project.godot
+++ b/game/project.godot
@@ -1,0 +1,26 @@
+; Engine configuration file.
+; It is best edited using the editor UI and not directly.
+; Format: ini-style
+
+config_version=5
+
+[application]
+config/name="Viktor Orban: Endless Escape"
+run/main_scene="res://scenes/main.tscn"
+config/icon="res://icon.svg"
+
+[display]
+window/size/viewport_width=1280
+window/size/viewport_height=720
+
+[input]
+ui_accept={"deadzone":0.5,"events":[{"type":"key","physical_keycode":32,"keycode":32,"unicode":32},{"type":"joy_button","device":0,"joy_button":0},{"type":"mouse_button","button_index":1}]}
+runner_jump={"deadzone":0.5,"events":[{"type":"key","physical_keycode":32,"keycode":32,"unicode":32},{"type":"joy_button","device":0,"joy_button":0},{"type":"mouse_button","button_index":1}]}
+runner_slide={"deadzone":0.5,"events":[{"type":"key","physical_keycode":16777238,"keycode":16777238},{"type":"key","physical_keycode":16777237,"keycode":16777237},{"type":"mouse_button","button_index":2}]}
+runner_powerup={"deadzone":0.5,"events":[{"type":"key","physical_keycode":70,"keycode":70,"unicode":102},{"type":"joy_button","device":0,"joy_button":2}]}
+
+[physics]
+common/enable_pause_aware_picking=true
+
+[rendering]
+renderer/rendering_method="forward_plus"

--- a/game/resources/powerups/friends_family_motorcade.tres
+++ b/game/resources/powerups/friends_family_motorcade.tres
@@ -1,0 +1,13 @@
+[gd_resource type="FriendsFamilyMotorcade" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/powerups/friends_family_motorcade.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+id = "friends_family_motorcade"
+display_name = "Friends & Family Motorcade"
+description = "Allied aides form a shield wall but skim your coffers."
+duration = 6.0
+cooldown = 14.0
+shield_strength = 3
+drain_rate = 20.0

--- a/game/resources/powerups/nationalized_media_megaphone.tres
+++ b/game/resources/powerups/nationalized_media_megaphone.tres
@@ -1,0 +1,13 @@
+[gd_resource type="NationalizedMediaMegaphone" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/powerups/nationalized_media_megaphone.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+id = "nationalized_media_megaphone"
+display_name = "Nationalized Media Megaphone"
+description = "Flood the airwaves with spin to stall the chase."
+duration = 5.0
+cooldown = 18.0
+heat_multiplier = 0.4
+decay_bonus = -0.8

--- a/game/resources/powerups/public_works_jetpack.tres
+++ b/game/resources/powerups/public_works_jetpack.tres
@@ -1,0 +1,13 @@
+[gd_resource type="PublicWorksJetpack" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/powerups/public_works_jetpack.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+id = "public_works_jetpack"
+display_name = "Public Works Jetpack"
+description = "Repurposed public works funding fuels a temporary escape vector."
+duration = 4.0
+cooldown = 10.0
+ascent_boost = -300.0
+hover_grace = 0.25

--- a/game/scenes/collectibles/coin.tscn
+++ b/game/scenes/collectibles/coin.tscn
@@ -1,0 +1,46 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/collectibles/coin.gd" id="1"]
+
+[sub_resource type="CircleShape2D" id="1"]
+radius = 14.0
+
+[sub_resource type="Gradient" id="2"]
+colors = PackedColorArray(0.968627, 0.803922, 0.262745, 1, 0.941176, 0.533333, 0.113725, 1)
+offsets = PackedFloat32Array(0, 1)
+
+[sub_resource type="GradientTexture2D" id="3"]
+width = 28
+height = 28
+gradient = SubResource("2")
+
+[node name="Coin" type="Area2D"]
+script = ExtResource("1")
+monitoring = true
+monitorable = true
+collision_layer = 1
+collision_mask = 1
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("1")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = SubResource("3")
+
+[node name="SpinParticles" type="CPUParticles2D" parent="."]
+emission_shape = 2
+amount = 24
+lifetime = 0.6
+one_shot = false
+preprocess = 0.1
+speed_scale = 1.2
+explosiveness = 0.6
+spread = 0.6
+radial_accel = -8.0
+initial_velocity_min = 22.0
+initial_velocity_max = 42.0
+scale_amount_min = 0.6
+scale_amount_max = 0.9
+gravity = Vector2(0, 0)
+color = Color(0.996078, 0.847059, 0.341176, 1)
+texture = SubResource("3")

--- a/game/scenes/environment/border_block_a.tscn
+++ b/game/scenes/environment/border_block_a.tscn
@@ -1,0 +1,48 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/environment/segment_chunk.gd" id="1"]
+
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(1024, 80)
+
+[node name="BorderBlockA" type="Node2D"]
+script = ExtResource("1")
+segment_length = 1024.0
+heat_band = Vector2(2.0, 3.1)
+tags = PackedStringArray("border", "fence")
+
+[node name="Ground" type="StaticBody2D" parent="."]
+position = Vector2(512, 80)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Ground"]
+shape = SubResource("1")
+
+[node name="GroundVisual" type="Polygon2D" parent="."]
+color = Color(0.341176, 0.396078, 0.231373, 1)
+polygon = PackedVector2Array(0, 80, 1024, 80, 1024, 20, 0, 20)
+position = Vector2(0, 48)
+
+[node name="Fence" type="Polygon2D" parent="."]
+color = Color(0.741176, 0.760784, 0.807843, 1)
+polygon = PackedVector2Array(0, 0, 0, -180, 1024, -180, 1024, 0)
+position = Vector2(0, -40)
+
+[node name="Searchlight" type="Polygon2D" parent="."]
+color = Color(1, 0.909804, 0.54902, 0.5)
+polygon = PackedVector2Array(580, -160, 700, -40, 460, -40)
+
+[node name="PowerUpSpawn" type="Marker2D" parent="."]
+position = Vector2(620, -120)
+__meta__ = {"spawn_group": "powerups"}
+
+[node name="CoinTrail" type="Marker2D" parent="."]
+position = Vector2(220, -150)
+__meta__ = {"spawn_group": "coins"}
+
+[node name="CoinTrailMid" type="Marker2D" parent="."]
+position = Vector2(520, -110)
+__meta__ = {"spawn_group": "coins"}
+
+[node name="CoinTrailExit" type="Marker2D" parent="."]
+position = Vector2(880, -90)
+__meta__ = {"spawn_group": "coins"}

--- a/game/scenes/environment/charity_block_a.tscn
+++ b/game/scenes/environment/charity_block_a.tscn
@@ -1,0 +1,45 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/environment/segment_chunk.gd" id="1"]
+
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(1024, 64)
+
+[node name="CharityBlockA" type="Node2D"]
+script = ExtResource("1")
+segment_length = 1024.0
+heat_band = Vector2(0.0, 1.5)
+tags = PackedStringArray("charity", "streetscape")
+
+[node name="Ground" type="StaticBody2D" parent="."]
+position = Vector2(512, 64)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Ground"]
+position = Vector2(0, 0)
+shape = SubResource("1")
+
+[node name="GroundVisual" type="Polygon2D" parent="."]
+color = Color(0.905882, 0.588235, 0.266667, 1)
+polygon = PackedVector2Array(0, 64, 1024, 64, 1024, 0, 0, 0)
+position = Vector2(0, 64)
+
+[node name="Billboard" type="Polygon2D" parent="."]
+color = Color(0.886275, 0.262745, 0.34902, 1)
+polygon = PackedVector2Array(0, 0, 0, -160, 160, -160, 160, 0)
+position = Vector2(720, -16)
+
+[node name="PowerUpSpawn" type="Marker2D" parent="."]
+position = Vector2(760, -40)
+__meta__ = {"spawn_group": "powerups"}
+
+[node name="CoinTrail" type="Marker2D" parent="."]
+position = Vector2(420, -120)
+__meta__ = {"spawn_group": "coins"}
+
+[node name="CoinTrailMid" type="Marker2D" parent="."]
+position = Vector2(640, -72)
+__meta__ = {"spawn_group": "coins"}
+
+[node name="CoinTrailLow" type="Marker2D" parent="."]
+position = Vector2(260, -56)
+__meta__ = {"spawn_group": "coins"}

--- a/game/scenes/environment/media_block_a.tscn
+++ b/game/scenes/environment/media_block_a.tscn
@@ -1,0 +1,48 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/environment/segment_chunk.gd" id="1"]
+
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(1024, 72)
+
+[node name="MediaBlockA" type="Node2D"]
+script = ExtResource("1")
+segment_length = 1024.0
+heat_band = Vector2(1.0, 2.2)
+tags = PackedStringArray("media", "alley")
+
+[node name="Ground" type="StaticBody2D" parent="."]
+position = Vector2(512, 72)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Ground"]
+shape = SubResource("1")
+
+[node name="GroundVisual" type="Polygon2D" parent="."]
+color = Color(0.254902, 0.321569, 0.545098, 1)
+polygon = PackedVector2Array(0, 72, 1024, 72, 1024, 12, 0, 12)
+position = Vector2(0, 48)
+
+[node name="SatelliteVan" type="Polygon2D" parent="."]
+color = Color(0.658824, 0.823529, 0.905882, 1)
+polygon = PackedVector2Array(0, 0, 0, -96, 180, -96, 180, 0)
+position = Vector2(360, -24)
+
+[node name="BroadcastDish" type="Polygon2D" parent="SatelliteVan"]
+color = Color(0.941176, 0.956863, 0.972549, 1)
+polygon = PackedVector2Array(40, -96, 60, -140, 100, -96)
+
+[node name="PowerUpSpawn" type="Marker2D" parent="."]
+position = Vector2(540, -60)
+__meta__ = {"spawn_group": "powerups"}
+
+[node name="CoinTrail" type="Marker2D" parent="."]
+position = Vector2(840, -140)
+__meta__ = {"spawn_group": "coins"}
+
+[node name="CoinTrailLower" type="Marker2D" parent="."]
+position = Vector2(520, -96)
+__meta__ = {"spawn_group": "coins"}
+
+[node name="CoinTrailFront" type="Marker2D" parent="."]
+position = Vector2(260, -80)
+__meta__ = {"spawn_group": "coins"}

--- a/game/scenes/main.tscn
+++ b/game/scenes/main.tscn
@@ -1,0 +1,49 @@
+[gd_scene load_steps=13 format=3]
+
+[ext_resource type="Script" path="res://scripts/world.gd" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/player.tscn" id="2"]
+[ext_resource type="Script" path="res://scripts/environment/segment_spawner.gd" id="3"]
+[ext_resource type="Script" path="res://scripts/powerups/powerup_manager.gd" id="4"]
+[ext_resource type="EnvironmentTileset" path="res://tilesets/charity_tileset.tres" id="5"]
+[ext_resource type="EnvironmentTileset" path="res://tilesets/media_tileset.tres" id="6"]
+[ext_resource type="EnvironmentTileset" path="res://tilesets/border_tileset.tres" id="7"]
+[ext_resource type="PublicWorksJetpack" path="res://resources/powerups/public_works_jetpack.tres" id="8"]
+[ext_resource type="FriendsFamilyMotorcade" path="res://resources/powerups/friends_family_motorcade.tres" id="9"]
+[ext_resource type="NationalizedMediaMegaphone" path="res://resources/powerups/nationalized_media_megaphone.tres" id="10"]
+[ext_resource type="PackedScene" path="res://scenes/powerup_pickup.tscn" id="11"]
+[ext_resource type="PackedScene" path="res://scenes/collectibles/coin.tscn" id="12"]
+
+[node name="World" type="Node2D"]
+script = ExtResource("1")
+player_path = NodePath("Player")
+camera_path = NodePath("Camera2D")
+segment_spawner_path = NodePath("SegmentSpawner")
+powerup_manager_path = NodePath("PowerUpManager")
+powerup_pickup_scene = ExtResource("11")
+coin_pickup_scene = ExtResource("12")
+coin_value = 1.0
+coin_spawn_variance = 8.0
+position = Vector2(0, 0)
+
+[node name="SegmentSpawner" type="Node2D" parent="."]
+script = ExtResource("3")
+player_path = NodePath("../Player")
+tilesets = [ExtResource("5"), ExtResource("6"), ExtResource("7")]
+segments_ahead = 3
+recycle_margin = 800.0
+heat_ramp_rate = 0.016
+
+[node name="Player" parent="." instance=ExtResource("2")]
+position = Vector2(80, -96)
+
+[node name="Camera2D" type="Camera2D" parent="."]
+position = Vector2(80, -160)
+zoom = Vector2(1.2, 1.2)
+current = true
+
+[node name="PowerUpManager" type="Node" parent="."]
+script = ExtResource("4")
+player_path = NodePath("../Player")
+world_path = NodePath("..")
+available_powerups = [ExtResource("8"), ExtResource("9"), ExtResource("10")]
+randomize_queue = true

--- a/game/scenes/player.tscn
+++ b/game/scenes/player.tscn
@@ -1,0 +1,26 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scripts/player.gd" id="1"]
+
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(36, 64)
+
+[sub_resource type="Gradient" id="2"]
+colors = PackedColorArray(0.945098, 0.588235, 0.160784, 1, 0.631373, 0.0666667, 0.113725, 1)
+offsets = PackedFloat32Array(0, 1)
+
+[sub_resource type="GradientTexture2D" id="3"]
+width = 48
+height = 64
+gradient = SubResource("2")
+
+[node name="Player" type="CharacterBody2D"]
+script = ExtResource("1")
+
+[node name="Sprite" type="Sprite2D" parent="."]
+texture = SubResource("3")
+offset = Vector2(0, -16)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, -32)
+shape = SubResource("1")

--- a/game/scenes/powerup_pickup.tscn
+++ b/game/scenes/powerup_pickup.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/powerups/powerup_pickup.gd" id="1"]
+
+[sub_resource type="CircleShape2D" id="1"]
+radius = 18.0
+
+[sub_resource type="Gradient" id="2"]
+colors = PackedColorArray(0.984314, 0.815686, 0.290196, 1, 0.988235, 0.54902, 0.2, 1)
+offsets = PackedFloat32Array(0, 1)
+
+[sub_resource type="GradientTexture2D" id="3"]
+width = 32
+height = 32
+gradient = SubResource("2")
+
+[node name="PowerUpPickup" type="Area2D"]
+script = ExtResource("1")
+monitorable = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("1")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = SubResource("3")

--- a/game/scripts/collectibles/coin.gd
+++ b/game/scripts/collectibles/coin.gd
@@ -1,0 +1,26 @@
+extends Area2D
+class_name Coin
+
+signal collected(amount: float)
+
+@export var value: float = 1.0
+@export var spin_speed_degrees: float = 180.0
+
+var _world: RunnerWorld
+
+func _ready() -> void:
+    body_entered.connect(_on_body_entered)
+
+func _process(delta: float) -> void:
+    rotation += deg_to_rad(spin_speed_degrees) * delta
+
+func set_world(world: RunnerWorld) -> void:
+    _world = world
+
+func _on_body_entered(body: Node) -> void:
+    if not body is RunnerPlayer:
+        return
+    if _world:
+        _world.add_currency(value)
+    collected.emit(value)
+    queue_free()

--- a/game/scripts/environment/environment_tileset.gd
+++ b/game/scripts/environment/environment_tileset.gd
@@ -1,0 +1,19 @@
+extends Resource
+class_name EnvironmentTileset
+
+@export var id: StringName = &"default"
+@export var display_name: String = "Unnamed Tileset"
+@export var description: String = ""
+@export var heat_threshold: Vector2 = Vector2(0.0, 1.0)
+@export var weight: float = 1.0
+@export var segments: Array[PackedScene] = []
+@export var powerup_bias: PackedStringArray = []
+
+func pick_random_segment(rng: RandomNumberGenerator) -> PackedScene:
+    if segments.is_empty():
+        return null
+    var index := rng.randi_range(0, segments.size() - 1)
+    return segments[index]
+
+func contains_heat(heat: float) -> bool:
+    return heat >= heat_threshold.x and heat <= heat_threshold.y

--- a/game/scripts/environment/segment_chunk.gd
+++ b/game/scripts/environment/segment_chunk.gd
@@ -1,0 +1,25 @@
+extends Node2D
+class_name SegmentChunk
+
+@export var segment_length: float = 960.0
+@export var heat_band: Vector2 = Vector2(0.0, 1.0)
+@export var tags: PackedStringArray = []
+
+var spawn_markers := {}
+
+func _ready() -> void:
+    _cache_spawn_markers()
+
+func _cache_spawn_markers() -> void:
+    spawn_markers.clear()
+    for child in get_children():
+        if child is Marker2D:
+            var group := child.get_meta("spawn_group") if child.has_meta("spawn_group") else "default"
+            if not spawn_markers.has(group):
+                spawn_markers[group] = []
+            spawn_markers[group].append(child)
+
+func get_spawn_markers(group: StringName = &"default") -> Array:
+    if not spawn_markers.has(group):
+        return []
+    return spawn_markers[group]

--- a/game/scripts/environment/segment_spawner.gd
+++ b/game/scripts/environment/segment_spawner.gd
@@ -1,0 +1,104 @@
+extends Node2D
+class_name SegmentSpawner
+
+signal segment_spawned(segment: Node, tileset: EnvironmentTileset)
+signal segment_recycled(segment: Node, tileset: EnvironmentTileset)
+
+@export var player_path: NodePath
+@export var tilesets: Array[EnvironmentTileset] = []
+@export var segments_ahead: int = 4
+@export var recycle_margin: float = 640.0
+@export var heat_ramp_rate: float = 0.012
+@export var max_heat: float = 3.0
+
+var heat_level: float = 0.0
+
+var _player: Node2D
+var _rng := RandomNumberGenerator.new()
+var _active_segments: Array[Dictionary] = []
+var _next_spawn_x: float = 0.0
+
+func _ready() -> void:
+    if player_path != NodePath(""):
+        _player = get_node(player_path)
+    _rng.randomize()
+    while _active_segments.size() < segments_ahead:
+        _spawn_next_segment()
+
+func _process(delta: float) -> void:
+    if _player:
+        _maybe_spawn_segments()
+        _recycle_old_segments()
+    heat_level = clamp(heat_level + heat_ramp_rate * delta, 0.0, max_heat)
+
+func _maybe_spawn_segments() -> void:
+    var target_x := _player.global_position.x + 1600.0
+    while _next_spawn_x < target_x:
+        if not _spawn_next_segment():
+            break
+
+func _spawn_next_segment() -> bool:
+    var tileset := _select_tileset()
+    if tileset == null:
+        return false
+    var packed := tileset.pick_random_segment(_rng)
+    if packed == null:
+        return false
+    var instance := packed.instantiate()
+    if not instance:
+        return false
+    add_child(instance)
+    if instance is Node2D:
+        instance.position.x = _next_spawn_x
+    _active_segments.append({"node": instance, "tileset": tileset})
+    var length := 960.0
+    if instance is SegmentChunk:
+        length = instance.segment_length
+    _next_spawn_x += length
+    instance.set_meta("environment_tileset", tileset.id)
+    segment_spawned.emit(instance, tileset)
+    return true
+
+func _recycle_old_segments() -> void:
+    if _player == null:
+        return
+    var recycle_x := _player.global_position.x - recycle_margin
+    while _active_segments.size() > 0:
+        var entry := _active_segments[0]
+        var first: Node = entry.get("node")
+        var tileset: EnvironmentTileset = entry.get("tileset")
+        if first == null or not first is Node2D:
+            _active_segments.pop_front()
+            continue
+        if first.global_position.x + 1280.0 >= recycle_x:
+            break
+        _active_segments.pop_front()
+        first.queue_free()
+        segment_recycled.emit(first, tileset)
+
+func _select_tileset() -> EnvironmentTileset:
+    var available: Array[EnvironmentTileset] = []
+    var total_weight := 0.0
+    for tileset in tilesets:
+        if tileset == null:
+            continue
+        if tileset.contains_heat(heat_level):
+            available.append(tileset)
+            total_weight += max(tileset.weight, 0.001)
+    if available.is_empty():
+        available = tilesets.duplicate()
+        total_weight = 0.0
+        for tileset in available:
+            total_weight += max(tileset.weight, 0.001)
+    if available.is_empty():
+        return null
+    var pick := _rng.randf_range(0.0, total_weight)
+    var accumulator := 0.0
+    for tileset in available:
+        accumulator += max(tileset.weight, 0.001)
+        if pick <= accumulator:
+            return tileset
+    return available[-1]
+
+func set_player(player: Node2D) -> void:
+    _player = player

--- a/game/scripts/player.gd
+++ b/game/scripts/player.gd
@@ -1,0 +1,133 @@
+extends CharacterBody2D
+class_name RunnerPlayer
+
+signal slide_started
+signal slide_ended
+signal jetpack_started
+signal jetpack_ended
+signal shield_broken
+
+@export var run_speed: float = 420.0
+@export var acceleration: float = 30.0
+@export var jump_velocity: float = -620.0
+@export var gravity: float = 1800.0
+@export var max_fall_speed: float = 1400.0
+@export var slide_duration: float = 0.45
+@export var jetpack_hover_speed: float = -120.0
+@export var jetpack_duration: float = 3.5
+
+var current_speed: float = 0.0
+var _slide_timer: float = 0.0
+var _jetpack_timer: float = 0.0
+var _is_sliding: bool = false
+var _is_jetpacking: bool = false
+var _shield_health: int = 0
+
+@onready var collision_shape: CollisionShape2D = $CollisionShape2D
+@onready var _base_shape := collision_shape.shape.duplicate(true) if collision_shape.shape else null
+@onready var _slide_shape := _make_slide_shape()
+@onready var _base_collision_offset: Vector2 = collision_shape.position
+
+func _ready() -> void:
+    current_speed = run_speed
+
+func _physics_process(delta: float) -> void:
+    _apply_horizontal_acceleration(delta)
+    if _is_jetpacking:
+        _update_jetpack(delta)
+    else:
+        _apply_gravity(delta)
+        _handle_jump_input()
+        _handle_slide_input(delta)
+    move_and_slide()
+
+func _apply_horizontal_acceleration(delta: float) -> void:
+    current_speed = move_toward(current_speed, run_speed, acceleration * delta)
+    velocity.x = current_speed
+
+func _apply_gravity(delta: float) -> void:
+    if not is_on_floor():
+        velocity.y = clamp(velocity.y + gravity * delta, -INF, max_fall_speed)
+    elif velocity.y > 0.0:
+        velocity.y = 0.0
+
+func _handle_jump_input() -> void:
+    if Input.is_action_just_pressed("runner_jump") and is_on_floor():
+        velocity.y = jump_velocity
+
+func _handle_slide_input(delta: float) -> void:
+    if Input.is_action_just_pressed("runner_slide") and is_on_floor() and not _is_sliding:
+        _begin_slide()
+    if _is_sliding:
+        _slide_timer -= delta
+        if _slide_timer <= 0.0 or not Input.is_action_pressed("runner_slide"):
+            _end_slide()
+
+func _begin_slide() -> void:
+    _is_sliding = true
+    _slide_timer = slide_duration
+    if _slide_shape and _base_shape:
+        collision_shape.shape = _slide_shape
+        collision_shape.position = _base_collision_offset + Vector2(0, (_base_shape.size.y - _slide_shape.size.y) * 0.5)
+    slide_started.emit()
+
+func _end_slide() -> void:
+    _is_sliding = false
+    if _base_shape:
+        collision_shape.shape = _base_shape
+        collision_shape.position = _base_collision_offset
+    slide_ended.emit()
+
+func start_jetpack(duration: float = jetpack_duration) -> void:
+    _is_jetpacking = true
+    _jetpack_timer = duration
+    velocity.y = jetpack_hover_speed
+    jetpack_started.emit()
+
+func end_jetpack() -> void:
+    if not _is_jetpacking:
+        return
+    _is_jetpacking = false
+    jetpack_ended.emit()
+
+func _update_jetpack(delta: float) -> void:
+    velocity.y = move_toward(velocity.y, jetpack_hover_speed, 600.0 * delta)
+    _jetpack_timer -= delta
+    if _jetpack_timer <= 0.0:
+        end_jetpack()
+
+func apply_speed_multiplier(multiplier: float, duration: float) -> void:
+    run_speed *= multiplier
+    await get_tree().create_timer(duration).timeout
+    run_speed /= multiplier
+
+func add_shield(strength: int) -> void:
+    _shield_health = max(_shield_health, strength)
+
+func consume_shield_hit() -> bool:
+    if _shield_health <= 0:
+        return false
+    _shield_health -= 1
+    if _shield_health == 0:
+        shield_broken.emit()
+    return true
+
+func set_run_speed(target_speed: float) -> void:
+    run_speed = target_speed
+
+func has_shield() -> bool:
+    return _shield_health > 0
+
+func clear_shield(emit_signal: bool = true) -> void:
+    if _shield_health <= 0:
+        return
+    _shield_health = 0
+    if emit_signal:
+        shield_broken.emit()
+
+func _make_slide_shape() -> RectangleShape2D:
+    if _base_shape == null:
+        return RectangleShape2D.new()
+    var slide_shape := RectangleShape2D.new()
+    slide_shape.size = Vector2(_base_shape.size.x, _base_shape.size.y * 0.6)
+    return slide_shape

--- a/game/scripts/powerups/friends_family_motorcade.gd
+++ b/game/scripts/powerups/friends_family_motorcade.gd
@@ -1,0 +1,30 @@
+extends PowerUp
+class_name FriendsFamilyMotorcade
+
+@export var shield_strength: int = 3
+@export var drain_rate: float = 15.0
+
+var _timer: float = 0.0
+var _active: bool = false
+
+func activate(player: RunnerPlayer, world: Node) -> void:
+    _timer = duration
+    _active = true
+    player.add_shield(shield_strength)
+    if world.has_method("summon_motorcade"):
+        world.summon_motorcade(duration)
+
+func update(delta: float, player: RunnerPlayer, world: Node) -> void:
+    if not _active:
+        return
+    _timer -= delta
+    if world.has_method("drain_currency"):
+        world.drain_currency(drain_rate * delta)
+
+func deactivate(player: RunnerPlayer, world: Node) -> void:
+    if not _active:
+        return
+    _active = false
+    player.clear_shield(false)
+    if world.has_method("dismiss_motorcade"):
+        world.dismiss_motorcade()

--- a/game/scripts/powerups/nationalized_media_megaphone.gd
+++ b/game/scripts/powerups/nationalized_media_megaphone.gd
@@ -1,0 +1,18 @@
+extends PowerUp
+class_name NationalizedMediaMegaphone
+
+@export var heat_multiplier: float = 0.35
+@export var decay_bonus: float = -0.6
+
+var _applied: bool = false
+
+func activate(_player: RunnerPlayer, world: Node) -> void:
+    _applied = true
+    if world.has_method("apply_heat_modifier"):
+        world.apply_heat_modifier(heat_multiplier, duration, decay_bonus)
+
+func update(delta: float, _player: RunnerPlayer, world: Node) -> void:
+    pass
+
+func deactivate(_player: RunnerPlayer, _world: Node) -> void:
+    _applied = false

--- a/game/scripts/powerups/powerup.gd
+++ b/game/scripts/powerups/powerup.gd
@@ -1,0 +1,21 @@
+extends Resource
+class_name PowerUp
+
+@export var id: StringName = &"power_up"
+@export var display_name: String = "Power Up"
+@export var description: String = ""
+@export var duration: float = 3.0
+@export var cooldown: float = 8.0
+@export var icon: Texture2D
+
+func can_activate(_world: Node) -> bool:
+    return true
+
+func activate(_player: RunnerPlayer, _world: Node) -> void:
+    pass
+
+func update(_delta: float, _player: RunnerPlayer, _world: Node) -> void:
+    pass
+
+func deactivate(_player: RunnerPlayer, _world: Node) -> void:
+    pass

--- a/game/scripts/powerups/powerup_manager.gd
+++ b/game/scripts/powerups/powerup_manager.gd
@@ -1,0 +1,120 @@
+extends Node
+class_name PowerUpManager
+
+signal powerup_activated(powerup: PowerUp)
+signal powerup_finished(powerup: PowerUp)
+signal powerup_ready(powerup: PowerUp)
+
+@export var player_path: NodePath
+@export var world_path: NodePath
+@export var available_powerups: Array[PowerUp] = []
+@export var randomize_queue: bool = true
+
+var _player: RunnerPlayer
+var _world: Node
+var _active_powerup: PowerUp
+var _active_timer: float = 0.0
+var _cooldowns := {}
+var _rng := RandomNumberGenerator.new()
+var _ready_state := {}
+
+func _ready() -> void:
+    if player_path != NodePath(""):
+        _player = get_node(player_path)
+    if world_path != NodePath(""):
+        _world = get_node(world_path)
+    _rng.randomize()
+    for powerup in available_powerups:
+        _cooldowns[powerup.id] = INF
+        _ready_state[powerup.id] = false
+
+func _process(delta: float) -> void:
+    _update_cooldowns(delta)
+    if _active_powerup:
+        _active_timer -= delta
+        if _player and _world:
+            _active_powerup.update(delta, _player, _world)
+        if _active_timer <= 0.0:
+            _finish_active_powerup()
+    else:
+        if Input.is_action_just_pressed("runner_powerup"):
+            trigger_random_powerup()
+
+func trigger_random_powerup() -> bool:
+    var ready := _get_ready_powerups()
+    if ready.is_empty():
+        return false
+    var powerup := ready[0]
+    if randomize_queue and ready.size() > 1:
+        powerup = ready[_rng.randi_range(0, ready.size() - 1)]
+    return activate_powerup(powerup)
+
+func activate_powerup(powerup: PowerUp) -> bool:
+    if _active_powerup:
+        return false
+    if _world == null:
+        return false
+    if not powerup.can_activate(_world):
+        return false
+    if _cooldowns.get(powerup.id, 0.0) > 0.0:
+        return false
+    if _player == null:
+        return false
+    _active_powerup = powerup
+    _active_timer = powerup.duration
+    _cooldowns[powerup.id] = powerup.cooldown
+    _ready_state[powerup.id] = false
+    _active_powerup.activate(_player, _world)
+    powerup_activated.emit(powerup)
+    return true
+
+func _finish_active_powerup() -> void:
+    if not _active_powerup:
+        return
+    _active_powerup.deactivate(_player, _world)
+    powerup_finished.emit(_active_powerup)
+    _active_powerup = null
+    _active_timer = 0.0
+
+func _get_ready_powerups() -> Array[PowerUp]:
+    var ready: Array[PowerUp] = []
+    for powerup in available_powerups:
+        if powerup == null:
+            continue
+        if _cooldowns.get(powerup.id, 0.0) <= 0.0:
+            ready.append(powerup)
+    return ready
+
+func _update_cooldowns(delta: float) -> void:
+    for id in _cooldowns.keys():
+        var previous_ready := _ready_state.get(id, false)
+        _cooldowns[id] = max(_cooldowns[id] - delta, 0.0)
+        var is_ready := _cooldowns[id] <= 0.0
+        _ready_state[id] = is_ready
+        if is_ready and not previous_ready:
+            var powerup := _find_powerup(id)
+            if powerup:
+                powerup_ready.emit(powerup)
+
+func _find_powerup(id: StringName) -> PowerUp:
+    for powerup in available_powerups:
+        if powerup and powerup.id == id:
+            return powerup
+    return null
+
+func set_player(player: RunnerPlayer) -> void:
+    _player = player
+
+func set_world(world: Node) -> void:
+    _world = world
+
+func grant_powerup(id: StringName) -> void:
+    var powerup := _find_powerup(id)
+    if not powerup:
+        return
+    _cooldowns[id] = 0.0
+    _ready_state[id] = true
+    powerup_ready.emit(powerup)
+
+func get_powerup(id: StringName) -> PowerUp:
+    return _find_powerup(id)

--- a/game/scripts/powerups/powerup_pickup.gd
+++ b/game/scripts/powerups/powerup_pickup.gd
@@ -1,0 +1,43 @@
+extends Area2D
+class_name PowerUpPickup
+
+signal collected(powerup_id: StringName)
+
+@export var powerup_id: StringName = &"public_works_jetpack"
+@export var auto_activate: bool = true
+@export var sprite_color: Color = Color(0.984314, 0.815686, 0.290196, 1)
+
+var _powerup_manager: PowerUpManager
+
+func _ready() -> void:
+    connect("body_entered", Callable(self, "_on_body_entered"))
+    if has_node("Sprite2D"):
+        var sprite: Sprite2D = get_node("Sprite2D")
+        sprite.modulate = sprite_color
+
+func _on_body_entered(body: Node) -> void:
+    if not body is RunnerPlayer:
+        return
+    if _powerup_manager == null:
+        _powerup_manager = _find_powerup_manager()
+    if _powerup_manager:
+        if auto_activate:
+            _powerup_manager.grant_powerup(powerup_id)
+            var powerup := _powerup_manager.get_powerup(powerup_id)
+            if powerup:
+                _powerup_manager.activate_powerup(powerup)
+        else:
+            _powerup_manager.grant_powerup(powerup_id)
+    collected.emit(powerup_id)
+    queue_free()
+
+func assign_manager(manager: PowerUpManager) -> void:
+    _powerup_manager = manager
+
+func _find_powerup_manager() -> PowerUpManager:
+    var node := get_parent()
+    while node:
+        if node is PowerUpManager:
+            return node
+        node = node.get_parent()
+    return null

--- a/game/scripts/powerups/public_works_jetpack.gd
+++ b/game/scripts/powerups/public_works_jetpack.gd
@@ -1,0 +1,15 @@
+extends PowerUp
+class_name PublicWorksJetpack
+
+@export var ascent_boost: float = -240.0
+@export var hover_grace: float = 0.25
+
+func activate(player: RunnerPlayer, _world: Node) -> void:
+    player.start_jetpack(duration)
+
+func update(delta: float, player: RunnerPlayer, _world: Node) -> void:
+    if Input.is_action_pressed("runner_jump"):
+        player.velocity.y = min(player.velocity.y, ascent_boost)
+
+func deactivate(player: RunnerPlayer, _world: Node) -> void:
+    player.end_jetpack()

--- a/game/scripts/world.gd
+++ b/game/scripts/world.gd
@@ -1,0 +1,165 @@
+extends Node2D
+class_name RunnerWorld
+
+@export var player_path: NodePath
+@export var camera_path: NodePath
+@export var segment_spawner_path: NodePath
+@export var powerup_manager_path: NodePath
+@export var powerup_pickup_scene: PackedScene
+@export var coin_pickup_scene: PackedScene
+@export var coin_value: float = 1.0
+@export var coin_spawn_variance: float = 12.0
+@export var camera_lead: float = 320.0
+@export var camera_height_offset: float = 120.0
+@export var camera_smoothing: float = 6.0
+@export var speed_ramp_interval: float = 9.0
+@export var speed_ramp_amount: float = 18.0
+
+var coin_bank: float = 0.0
+var chase_heat: float = 0.0
+
+var _player: RunnerPlayer
+var _camera: Camera2D
+var _segment_spawner: SegmentSpawner
+var _powerup_manager: PowerUpManager
+var _speed_timer: float = 0.0
+var _motorcade_active: bool = false
+var _base_heat_ramp: float = 0.0
+var _heat_multiplier: float = 1.0
+var _heat_modifier_time: float = 0.0
+var _heat_decay_bonus: float = 0.0
+var _rng := RandomNumberGenerator.new()
+
+func _ready() -> void:
+    if player_path != NodePath(""):
+        _player = get_node(player_path)
+    if camera_path != NodePath(""):
+        _camera = get_node(camera_path)
+    if segment_spawner_path != NodePath(""):
+        _segment_spawner = get_node(segment_spawner_path)
+    if powerup_manager_path != NodePath(""):
+        _powerup_manager = get_node(powerup_manager_path)
+        if _powerup_manager:
+            if _player:
+                _powerup_manager.set_player(_player)
+            _powerup_manager.set_world(self)
+    _speed_timer = speed_ramp_interval
+    if _segment_spawner:
+        _base_heat_ramp = _segment_spawner.heat_ramp_rate
+        if _player:
+            _segment_spawner.set_player(_player)
+            _segment_spawner.player_path = _player.get_path()
+        _segment_spawner.segment_spawned.connect(Callable(self, "_on_segment_spawned"))
+    _rng.randomize()
+
+func _process(delta: float) -> void:
+    if _player:
+        _update_camera(delta)
+        _update_speed(delta)
+    if _segment_spawner:
+        chase_heat = _segment_spawner.heat_level
+    _update_heat_modifier(delta)
+
+func add_currency(amount: float) -> void:
+    coin_bank += amount
+
+func drain_currency(amount: float) -> void:
+    coin_bank = max(0.0, coin_bank - amount)
+
+func summon_motorcade(_duration: float) -> void:
+    _motorcade_active = true
+
+func dismiss_motorcade() -> void:
+    _motorcade_active = false
+
+func apply_heat_modifier(multiplier: float, duration: float, decay_bonus: float = 0.0) -> void:
+    _heat_multiplier = multiplier
+    _heat_modifier_time = duration
+    _heat_decay_bonus = decay_bonus
+    if _segment_spawner:
+        _segment_spawner.heat_ramp_rate = _base_heat_ramp * multiplier
+
+func _update_camera(delta: float) -> void:
+    if not _camera or not _player:
+        return
+    var target := Vector2(_player.global_position.x + camera_lead, _player.global_position.y - camera_height_offset)
+    var weight := clamp(delta * camera_smoothing, 0.0, 1.0)
+    _camera.global_position = _camera.global_position.lerp(target, weight)
+
+func _update_speed(delta: float) -> void:
+    if not _player:
+        return
+    _speed_timer -= delta
+    if _speed_timer <= 0.0:
+        _player.run_speed += speed_ramp_amount
+        _speed_timer = speed_ramp_interval
+
+func _update_heat_modifier(delta: float) -> void:
+    if _heat_modifier_time <= 0.0:
+        return
+    _heat_modifier_time -= delta
+    if _heat_modifier_time <= 0.0:
+        _heat_multiplier = 1.0
+        if _segment_spawner:
+            _segment_spawner.heat_ramp_rate = _base_heat_ramp
+            _segment_spawner.heat_level = clamp(_segment_spawner.heat_level + _heat_decay_bonus, 0.0, _segment_spawner.max_heat)
+        _heat_decay_bonus = 0.0
+
+func _on_segment_spawned(segment: Node, tileset: EnvironmentTileset) -> void:
+    if segment == null or not segment is SegmentChunk:
+        return
+    var chunk := segment as SegmentChunk
+    _spawn_coins_for_segment(segment, chunk)
+    _spawn_powerup_for_segment(segment, chunk, tileset)
+
+func _spawn_coins_for_segment(segment: Node, chunk: SegmentChunk) -> void:
+    if coin_pickup_scene == null:
+        return
+    var markers := chunk.get_spawn_markers("coins")
+    if markers.is_empty():
+        return
+    for marker: Marker2D in markers:
+        var coin_instance := coin_pickup_scene.instantiate()
+        if coin_instance == null:
+            continue
+        segment.add_child(coin_instance)
+        var coin := coin_instance as Coin
+        if coin:
+            coin.set_world(self)
+            coin.value = coin_value
+        var offset := Vector2.ZERO
+        if coin_spawn_variance > 0.0:
+            offset = Vector2(
+                _rng.randf_range(-coin_spawn_variance, coin_spawn_variance),
+                _rng.randf_range(-coin_spawn_variance, coin_spawn_variance) * 0.5
+            )
+        coin_instance.position = marker.position + offset
+
+func _spawn_powerup_for_segment(segment: Node, chunk: SegmentChunk, tileset: EnvironmentTileset) -> void:
+    if powerup_pickup_scene == null or _powerup_manager == null:
+        return
+    var markers := chunk.get_spawn_markers("powerups")
+    if markers.is_empty():
+        return
+    var marker: Marker2D = markers[_rng.randi_range(0, markers.size() - 1)]
+    var pickup: PowerUpPickup = powerup_pickup_scene.instantiate()
+    if pickup == null:
+        return
+    segment.add_child(pickup)
+    pickup.position = marker.position
+    pickup.assign_manager(_powerup_manager)
+    pickup.powerup_id = _select_powerup_for_tileset(tileset)
+
+func _select_powerup_for_tileset(tileset: EnvironmentTileset) -> StringName:
+    if tileset and tileset.powerup_bias.size() > 0:
+        var index := _rng.randi_range(0, tileset.powerup_bias.size() - 1)
+        return StringName(tileset.powerup_bias[index])
+    if _powerup_manager:
+        var pool: Array[StringName] = []
+        for powerup in _powerup_manager.available_powerups:
+            if powerup:
+                pool.append(powerup.id)
+        if pool.size() > 0:
+            var idx := _rng.randi_range(0, pool.size() - 1)
+            return pool[idx]
+    return &"public_works_jetpack"

--- a/game/tilesets/border_tileset.tres
+++ b/game/tilesets/border_tileset.tres
@@ -1,0 +1,14 @@
+[gd_resource type="EnvironmentTileset" load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scripts/environment/environment_tileset.gd" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/environment/border_block_a.tscn" id="2"]
+
+[resource]
+script = ExtResource("1")
+id = "border_fence"
+display_name = "Border Fence Sprint"
+description = "Spotlights and barricades demand tight timing as the chase peaks."
+heat_threshold = Vector2(2.0, 3.2)
+weight = 1.4
+segments = [ExtResource("2")]
+powerup_bias = PackedStringArray("nationalized_media_megaphone")

--- a/game/tilesets/charity_tileset.tres
+++ b/game/tilesets/charity_tileset.tres
@@ -1,0 +1,14 @@
+[gd_resource type="EnvironmentTileset" load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scripts/environment/environment_tileset.gd" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/environment/charity_block_a.tscn" id="2"]
+
+[resource]
+script = ExtResource("1")
+id = "charity_strip"
+display_name = "Charity Fundraiser Strip"
+description = "Neon donor galas packed with coin trails and low-risk hazards."
+heat_threshold = Vector2(0.0, 1.2)
+weight = 1.2
+segments = [ExtResource("2")]
+powerup_bias = PackedStringArray("public_works_jetpack")

--- a/game/tilesets/media_tileset.tres
+++ b/game/tilesets/media_tileset.tres
@@ -1,0 +1,14 @@
+[gd_resource type="EnvironmentTileset" load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scripts/environment/environment_tileset.gd" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/environment/media_block_a.tscn" id="2"]
+
+[resource]
+script = ExtResource("1")
+id = "media_monopoly"
+display_name = "Media Monopoly Alley"
+description = "Broadcast vans spew propaganda, narrowing the safe lanes."
+heat_threshold = Vector2(1.0, 2.3)
+weight = 1.0
+segments = [ExtResource("2")]
+powerup_bias = PackedStringArray("friends_family_motorcade")


### PR DESCRIPTION
## Summary
- add a reusable Coin collectible scene and script that credits the runner's currency bank when picked up
- extend the world controller to spawn coins from segment markers alongside power-up pickups with tunable value and variance
- seed each environment block with multiple coin marker positions so procedural segments feel populated

## Testing
- not run (Godot CLI not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cbd8c28b24832fb8b8c7dc73bb23f1