### PR TITLE
Implement HUD and coin collection feedback

### DIFF
--- a/game/scenes/main.tscn
+++ b/game/scenes/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3]
+[gd_scene load_steps=14 format=3]
 
 [ext_resource type="Script" path="res://scripts/world.gd" id="1"]
 [ext_resource type="PackedScene" path="res://scenes/player.tscn" id="2"]
@@ -12,6 +12,7 @@
 [ext_resource type="NationalizedMediaMegaphone" path="res://resources/powerups/nationalized_media_megaphone.tres" id="10"]
 [ext_resource type="PackedScene" path="res://scenes/powerup_pickup.tscn" id="11"]
 [ext_resource type="PackedScene" path="res://scenes/collectibles/coin.tscn" id="12"]
+[ext_resource type="Script" path="res://scripts/ui/hud.gd" id="13"]
 
 [node name="World" type="Node2D"]
 script = ExtResource("1")
@@ -19,6 +20,7 @@ player_path = NodePath("Player")
 camera_path = NodePath("Camera2D")
 segment_spawner_path = NodePath("SegmentSpawner")
 powerup_manager_path = NodePath("PowerUpManager")
+hud_path = NodePath("HUD")
 powerup_pickup_scene = ExtResource("11")
 coin_pickup_scene = ExtResource("12")
 coin_value = 1.0
@@ -47,3 +49,50 @@ player_path = NodePath("../Player")
 world_path = NodePath("..")
 available_powerups = [ExtResource("8"), ExtResource("9"), ExtResource("10")]
 randomize_queue = true
+
+[node name="HUD" type="CanvasLayer" parent="."]
+script = ExtResource("13")
+
+[node name="MarginContainer" type="MarginContainer" parent="HUD"]
+anchor_right = 0.0
+anchor_bottom = 0.0
+offset_left = 16.0
+offset_top = 16.0
+offset_right = 296.0
+offset_bottom = 176.0
+theme_override_constants/margin_left = 12
+theme_override_constants/margin_top = 12
+theme_override_constants/margin_right = 12
+theme_override_constants/margin_bottom = 12
+
+[node name="PanelContainer" type="PanelContainer" parent="HUD/MarginContainer"]
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="ContentMargin" type="MarginContainer" parent="HUD/MarginContainer/PanelContainer"]
+theme_override_constants/margin_left = 12
+theme_override_constants/margin_top = 12
+theme_override_constants/margin_right = 12
+theme_override_constants/margin_bottom = 12
+
+[node name="VBoxContainer" type="VBoxContainer" parent="HUD/MarginContainer/PanelContainer/ContentMargin"]
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 8
+
+[node name="CurrencyLabel" type="Label" parent="HUD/MarginContainer/PanelContainer/ContentMargin/VBoxContainer"]
+unique_name_in_owner = true
+text = "Coin Bank: 0"
+theme_override_font_sizes/font_size = 22
+
+[node name="DistanceLabel" type="Label" parent="HUD/MarginContainer/PanelContainer/ContentMargin/VBoxContainer"]
+unique_name_in_owner = true
+text = "Distance: 0 m"
+theme_override_font_sizes/font_size = 18
+
+[node name="MotorcadeLabel" type="Label" parent="HUD/MarginContainer/PanelContainer/ContentMargin/VBoxContainer"]
+unique_name_in_owner = true
+visible = false
+text = "Motorcade Upkeep: -0/s"
+theme_override_font_colors/font_color = Color(1, 0.854902, 0.572549, 1)
+theme_override_font_sizes/font_size = 16

--- a/game/scripts/powerups/friends_family_motorcade.gd
+++ b/game/scripts/powerups/friends_family_motorcade.gd
@@ -12,7 +12,7 @@ func activate(player: RunnerPlayer, world: Node) -> void:
     _active = true
     player.add_shield(shield_strength)
     if world.has_method("summon_motorcade"):
-        world.summon_motorcade(duration)
+        world.summon_motorcade(duration, drain_rate)
 
 func update(delta: float, player: RunnerPlayer, world: Node) -> void:
     if not _active:

--- a/game/scripts/ui/hud.gd
+++ b/game/scripts/ui/hud.gd
@@ -1,0 +1,121 @@
+extends CanvasLayer
+class_name RunnerHUD
+
+@export var distance_pixels_per_unit: float = 32.0
+@export var show_decimal_distance: bool = false
+
+@onready var _currency_label: Label = %CurrencyLabel
+@onready var _distance_label: Label = %DistanceLabel
+@onready var _motorcade_label: Label = %MotorcadeLabel
+
+var _world: RunnerWorld
+var _currency_base_modulate := Color(1, 1, 1, 1)
+var _distance_base_modulate := Color(1, 1, 1, 1)
+var _motorcade_base_modulate := Color(1, 1, 1, 1)
+
+func _ready() -> void:
+    if _currency_label:
+        _currency_base_modulate = _currency_label.modulate
+    if _distance_label:
+        _distance_base_modulate = _distance_label.modulate
+    if _motorcade_label:
+        _motorcade_base_modulate = _motorcade_label.modulate
+        _motorcade_label.visible = false
+    _refresh_currency(0.0)
+    _refresh_distance(0.0)
+
+func set_world(world: RunnerWorld) -> void:
+    if _world == world:
+        return
+    _disconnect_world()
+    _world = world
+    _connect_world()
+    if _world:
+        _refresh_currency(_world.coin_bank)
+        _refresh_distance(_world.distance_traveled)
+        _update_motorcade_display(_world.is_motorcade_active(), _world.get_motorcade_drain_rate())
+
+func _disconnect_world() -> void:
+    if _world == null:
+        return
+    if _world.is_connected("currency_changed", Callable(self, "_on_currency_changed")):
+        _world.disconnect("currency_changed", Callable(self, "_on_currency_changed"))
+    if _world.is_connected("currency_collected", Callable(self, "_on_currency_collected")):
+        _world.disconnect("currency_collected", Callable(self, "_on_currency_collected"))
+    if _world.is_connected("currency_drained", Callable(self, "_on_currency_drained")):
+        _world.disconnect("currency_drained", Callable(self, "_on_currency_drained"))
+    if _world.is_connected("distance_changed", Callable(self, "_on_distance_changed")):
+        _world.disconnect("distance_changed", Callable(self, "_on_distance_changed"))
+    if _world.is_connected("motorcade_state_changed", Callable(self, "_on_motorcade_state_changed")):
+        _world.disconnect("motorcade_state_changed", Callable(self, "_on_motorcade_state_changed"))
+
+func _connect_world() -> void:
+    if _world == null:
+        return
+    _world.currency_changed.connect(_on_currency_changed)
+    _world.currency_collected.connect(_on_currency_collected)
+    _world.currency_drained.connect(_on_currency_drained)
+    _world.distance_changed.connect(_on_distance_changed)
+    _world.motorcade_state_changed.connect(_on_motorcade_state_changed)
+
+func _on_currency_changed(total: float) -> void:
+    _refresh_currency(total)
+
+func _on_currency_collected(amount: float) -> void:
+    _flash_label(_currency_label, Color(0.8, 1.0, 0.6))
+
+func _on_currency_drained(amount: float) -> void:
+    _flash_label(_currency_label, Color(1.0, 0.6, 0.6))
+    if _motorcade_label and _motorcade_label.visible:
+        _flash_label(_motorcade_label, Color(1.0, 0.7, 0.4))
+
+func _on_distance_changed(distance: float) -> void:
+    _refresh_distance(distance)
+
+func _on_motorcade_state_changed(active: bool, drain_rate: float) -> void:
+    _update_motorcade_display(active, drain_rate)
+
+func _refresh_currency(total: float) -> void:
+    if not _currency_label:
+        return
+    var rounded := int(round(total))
+    _currency_label.text = "Coin Bank: %d" % rounded
+
+func _refresh_distance(distance: float) -> void:
+    if not _distance_label:
+        return
+    var units := distance
+    if distance_pixels_per_unit > 0.0:
+        units = distance / distance_pixels_per_unit
+    if show_decimal_distance:
+        _distance_label.text = "Distance: %.1f m" % units
+    else:
+        _distance_label.text = "Distance: %d m" % int(units)
+
+func _update_motorcade_display(active: bool, drain_rate: float) -> void:
+    if not _motorcade_label:
+        return
+    if active:
+        _motorcade_label.visible = true
+        if drain_rate > 0.0:
+            _motorcade_label.text = "Motorcade Upkeep: -%.1f/s" % drain_rate
+        else:
+            _motorcade_label.text = "Motorcade Escort Active"
+    else:
+        _motorcade_label.visible = false
+        _motorcade_label.text = ""
+        _motorcade_label.modulate = _motorcade_base_modulate
+
+func _flash_label(label: CanvasItem, highlight_color: Color) -> void:
+    if label == null:
+        return
+    var base_color := Color(1, 1, 1, 1)
+    if label == _currency_label:
+        base_color = _currency_base_modulate
+    elif label == _distance_label:
+        base_color = _distance_base_modulate
+    elif label == _motorcade_label:
+        base_color = _motorcade_base_modulate
+    label.modulate = highlight_color
+    var tween := create_tween()
+    tween.tween_property(label, "modulate", base_color, 0.35).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)


### PR DESCRIPTION
## Summary
- add scoring and distance tracking hooks to the world so coin pickups update the bank and emit HUD-friendly signals
- update the motorcade power-up to surface its drain rate
- add a HUD canvas layer and script that displays coin totals, distance travelled, and motorcade upkeep feedback

## Testing
- not run (Godot executable not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cbdd626c9c832f8d66cb29b540dd32