### PR TITLE
Add hazard spawning, collision handling, and run summary

### DIFF
--- a/game/scenes/environment/border_block_a.tscn
+++ b/game/scenes/environment/border_block_a.tscn
@@ -46,3 +46,11 @@ __meta__ = {"spawn_group": "coins"}
 [node name="CoinTrailExit" type="Marker2D" parent="."]
 position = Vector2(880, -90)
 __meta__ = {"spawn_group": "coins"}
+
+[node name="ObstacleSpawn" type="Marker2D" parent="."]
+position = Vector2(520, 0)
+__meta__ = {"spawn_group": "obstacles"}
+
+[node name="EnemyTower" type="Marker2D" parent="."]
+position = Vector2(300, -28)
+__meta__ = {"spawn_group": "enemies"}

--- a/game/scenes/environment/charity_block_a.tscn
+++ b/game/scenes/environment/charity_block_a.tscn
@@ -43,3 +43,11 @@ __meta__ = {"spawn_group": "coins"}
 [node name="CoinTrailLow" type="Marker2D" parent="."]
 position = Vector2(260, -56)
 __meta__ = {"spawn_group": "coins"}
+
+[node name="ObstacleSpawn" type="Marker2D" parent="."]
+position = Vector2(560, 0)
+__meta__ = {"spawn_group": "obstacles"}
+
+[node name="EnemySpawn" type="Marker2D" parent="."]
+position = Vector2(820, -12)
+__meta__ = {"spawn_group": "enemies"}

--- a/game/scenes/environment/media_block_a.tscn
+++ b/game/scenes/environment/media_block_a.tscn
@@ -46,3 +46,11 @@ __meta__ = {"spawn_group": "coins"}
 [node name="CoinTrailFront" type="Marker2D" parent="."]
 position = Vector2(260, -80)
 __meta__ = {"spawn_group": "coins"}
+
+[node name="ObstacleSpawn" type="Marker2D" parent="."]
+position = Vector2(620, 0)
+__meta__ = {"spawn_group": "obstacles"}
+
+[node name="EnemyPatrolSpawn" type="Marker2D" parent="."]
+position = Vector2(340, -20)
+__meta__ = {"spawn_group": "enemies"}

--- a/game/scenes/hazards/patrol_guard.tscn
+++ b/game/scenes/hazards/patrol_guard.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/hazards/patrol_guard.gd" id="1"]
+
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(36, 56)
+
+[node name="PatrolGuard" type="CharacterBody2D"]
+script = ExtResource("1")
+heat_damage = 1.6
+destroy_on_hit = true
+defeat_reason = "Nabbed by patrol"
+patrol_speed = 140.0
+patrol_distance = 180.0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, -28)
+shape = SubResource("1")
+
+[node name="Body" type="Polygon2D" parent="."]
+color = Color(0.345098, 0.192157, 0.560784, 1)
+polygon = PackedVector2Array(-18, 0, -12, -48, 0, -56, 12, -48, 18, 0)
+
+[node name="Visor" type="Polygon2D" parent="."]
+position = Vector2(0, -40)
+color = Color(0.937255, 0.894118, 0.72549, 1)
+polygon = PackedVector2Array(-12, 4, 12, 4, 8, -4, -8, -4)

--- a/game/scenes/hazards/spike_barrier.tscn
+++ b/game/scenes/hazards/spike_barrier.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/hazards/obstacle_hazard.gd" id="1"]
+
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(64, 48)
+
+[node name="SpikeBarrier" type="StaticBody2D"]
+script = ExtResource("1")
+heat_damage = 1.2
+destroy_on_hit = true
+defeat_reason = "Impaled on barricade"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, -24)
+shape = SubResource("1")
+
+[node name="Spikes" type="Polygon2D" parent="."]
+color = Color(0.792157, 0.207843, 0.227451, 1)
+polygon = PackedVector2Array(-32, 0, -16, -40, 0, 0, 16, -40, 32, 0)

--- a/game/scenes/main.tscn
+++ b/game/scenes/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3]
+[gd_scene load_steps=16 format=3]
 
 [ext_resource type="Script" path="res://scripts/world.gd" id="1"]
 [ext_resource type="PackedScene" path="res://scenes/player.tscn" id="2"]
@@ -13,6 +13,8 @@
 [ext_resource type="PackedScene" path="res://scenes/powerup_pickup.tscn" id="11"]
 [ext_resource type="PackedScene" path="res://scenes/collectibles/coin.tscn" id="12"]
 [ext_resource type="Script" path="res://scripts/ui/hud.gd" id="13"]
+[ext_resource type="PackedScene" path="res://scenes/hazards/spike_barrier.tscn" id="14"]
+[ext_resource type="PackedScene" path="res://scenes/hazards/patrol_guard.tscn" id="15"]
 
 [node name="World" type="Node2D"]
 script = ExtResource("1")
@@ -25,6 +27,8 @@ powerup_pickup_scene = ExtResource("11")
 coin_pickup_scene = ExtResource("12")
 coin_value = 1.0
 coin_spawn_variance = 8.0
+obstacle_scenes = [ExtResource("14")]
+enemy_scenes = [ExtResource("15")]
 position = Vector2(0, 0)
 
 [node name="SegmentSpawner" type="Node2D" parent="."]
@@ -96,3 +100,62 @@ visible = false
 text = "Motorcade Upkeep: -0/s"
 theme_override_font_colors/font_color = Color(1, 0.854902, 0.572549, 1)
 theme_override_font_sizes/font_size = 16
+
+[node name="RunSummary" type="Control" parent="HUD"]
+unique_name_in_owner = true
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 1
+
+[node name="Dimmer" type="ColorRect" parent="HUD/RunSummary"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(0, 0, 0, 0.55)
+
+[node name="CenterContainer" type="CenterContainer" parent="HUD/RunSummary"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="PanelContainer" type="PanelContainer" parent="HUD/RunSummary/CenterContainer"]
+custom_minimum_size = Vector2(360, 240)
+
+[node name="ContentMargin" type="MarginContainer" parent="HUD/RunSummary/CenterContainer/PanelContainer"]
+theme_override_constants/margin_left = 18
+theme_override_constants/margin_top = 18
+theme_override_constants/margin_right = 18
+theme_override_constants/margin_bottom = 18
+
+[node name="VBoxContainer" type="VBoxContainer" parent="HUD/RunSummary/CenterContainer/PanelContainer/ContentMargin"]
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 12
+
+[node name="SummaryReasonLabel" type="Label" parent="HUD/RunSummary/CenterContainer/PanelContainer/ContentMargin/VBoxContainer"]
+unique_name_in_owner = true
+text = "Run Complete"
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 28
+
+[node name="SummaryDistanceLabel" type="Label" parent="HUD/RunSummary/CenterContainer/PanelContainer/ContentMargin/VBoxContainer"]
+unique_name_in_owner = true
+text = "Distance: 0 m"
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 20
+
+[node name="SummaryCoinsLabel" type="Label" parent="HUD/RunSummary/CenterContainer/PanelContainer/ContentMargin/VBoxContainer"]
+unique_name_in_owner = true
+text = "Coins: 0"
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 20
+
+[node name="SummaryHeatLabel" type="Label" parent="HUD/RunSummary/CenterContainer/PanelContainer/ContentMargin/VBoxContainer"]
+unique_name_in_owner = true
+text = "Heat: 0.0"
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 18
+
+[node name="RetryButton" type="Button" parent="HUD/RunSummary/CenterContainer/PanelContainer/ContentMargin/VBoxContainer"]
+unique_name_in_owner = true
+text = "Retry"
+size_flags_horizontal = 4

--- a/game/scripts/hazards/obstacle_hazard.gd
+++ b/game/scripts/hazards/obstacle_hazard.gd
@@ -1,0 +1,26 @@
+extends StaticBody2D
+class_name ObstacleHazard
+
+@export var heat_damage: float = 1.0
+@export var destroy_on_hit: bool = false
+@export var defeat_reason: String = "Stumbled into barricade"
+
+func _ready() -> void:
+    add_to_group("hazard")
+
+func get_heat_damage() -> float:
+    return heat_damage
+
+func should_destroy_on_hit() -> bool:
+    return destroy_on_hit
+
+func get_defeat_reason() -> String:
+    return defeat_reason
+
+func on_player_blocked(_player: RunnerPlayer, _world: RunnerWorld) -> void:
+    if destroy_on_hit:
+        queue_free()
+
+func on_player_damaged(_player: RunnerPlayer, _world: RunnerWorld) -> void:
+    if destroy_on_hit:
+        queue_free()

--- a/game/scripts/hazards/patrol_guard.gd
+++ b/game/scripts/hazards/patrol_guard.gd
@@ -1,0 +1,48 @@
+extends CharacterBody2D
+class_name PatrolGuard
+
+@export var heat_damage: float = 1.5
+@export var destroy_on_hit: bool = true
+@export var defeat_reason: String = "Caught by guard"
+@export var patrol_speed: float = 120.0
+@export var patrol_distance: float = 160.0
+@export var start_direction: int = 1
+
+var _origin: Vector2
+var _direction: int = 1
+
+func _ready() -> void:
+    add_to_group("hazard")
+    _origin = global_position
+    _direction = 1 if start_direction >= 0 else -1
+    set_physics_process(patrol_speed > 0.0)
+
+func _physics_process(delta: float) -> void:
+    if patrol_speed <= 0.0:
+        velocity = Vector2.ZERO
+        return
+    velocity.x = patrol_speed * _direction
+    velocity.y = 0.0
+    move_and_slide()
+    var offset := global_position.x - _origin.x
+    if abs(offset) >= patrol_distance:
+        _direction *= -1
+        var clamped := clamp(offset, -patrol_distance, patrol_distance)
+        global_position.x = _origin.x + clamped
+
+func get_heat_damage() -> float:
+    return heat_damage
+
+func should_destroy_on_hit() -> bool:
+    return destroy_on_hit
+
+func get_defeat_reason() -> String:
+    return defeat_reason
+
+func on_player_blocked(_player: RunnerPlayer, _world: RunnerWorld) -> void:
+    if destroy_on_hit:
+        queue_free()
+
+func on_player_damaged(_player: RunnerPlayer, _world: RunnerWorld) -> void:
+    if destroy_on_hit:
+        queue_free()


### PR DESCRIPTION
## Summary
- add obstacle and patrol hazard scenes with spawn markers in each segment
- extend the player and world scripts to detect hazard collisions, spend shields/heat, and end a run
- surface a post-run summary overlay with restart support and final scoring

## Testing
- godot4 --headless --quit *(fails: command not found)*
- godot --headless --quit *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe344f784832fbc2ac0953afe9c2a