### PR TITLE
Fix Godot typing warnings treated as errors

### DIFF
--- a/game/scripts/environment/environment_tileset.gd
+++ b/game/scripts/environment/environment_tileset.gd
@@ -12,7 +12,7 @@ class_name EnvironmentTileset
 func pick_random_segment(rng: RandomNumberGenerator) -> PackedScene:
     if segments.is_empty():
         return null
-    var index := rng.randi_range(0, segments.size() - 1)
+    var index: int = rng.randi_range(0, segments.size() - 1)
     return segments[index]
 
 func contains_heat(heat: float) -> bool:

--- a/game/scripts/environment/segment_chunk.gd
+++ b/game/scripts/environment/segment_chunk.gd
@@ -5,7 +5,7 @@ class_name SegmentChunk
 @export var heat_band: Vector2 = Vector2(0.0, 1.0)
 @export var tags: PackedStringArray = []
 
-var spawn_markers := {}
+var spawn_markers: Dictionary[StringName, Array[Marker2D]] = {}
 
 func _ready() -> void:
     _cache_spawn_markers()
@@ -14,12 +14,14 @@ func _cache_spawn_markers() -> void:
     spawn_markers.clear()
     for child in get_children():
         if child is Marker2D:
-            var group := child.get_meta("spawn_group") if child.has_meta("spawn_group") else "default"
+            var group: StringName = &"default"
+            if child.has_meta("spawn_group"):
+                group = StringName(child.get_meta("spawn_group"))
             if not spawn_markers.has(group):
-                spawn_markers[group] = []
+                spawn_markers[group] = [] as Array[Marker2D]
             spawn_markers[group].append(child)
 
-func get_spawn_markers(group: StringName = &"default") -> Array:
+func get_spawn_markers(group: StringName = &"default") -> Array[Marker2D]:
     if not spawn_markers.has(group):
-        return []
+        return [] as Array[Marker2D]
     return spawn_markers[group]

--- a/game/scripts/environment/segment_spawner.gd
+++ b/game/scripts/environment/segment_spawner.gd
@@ -13,8 +13,8 @@ signal segment_recycled(segment: Node, tileset: EnvironmentTileset)
 
 var heat_level: float = 0.0
 
-var _player: Node2D
-var _rng := RandomNumberGenerator.new()
+var _player: Node2D = null
+var _rng: RandomNumberGenerator = RandomNumberGenerator.new()
 var _active_segments: Array[Dictionary] = []
 var _next_spawn_x: float = 0.0
 
@@ -32,26 +32,26 @@ func _process(delta: float) -> void:
     heat_level = clamp(heat_level + heat_ramp_rate * delta, 0.0, max_heat)
 
 func _maybe_spawn_segments() -> void:
-    var target_x := _player.global_position.x + 1600.0
+    var target_x: float = _player.global_position.x + 1600.0
     while _next_spawn_x < target_x:
         if not _spawn_next_segment():
             break
 
 func _spawn_next_segment() -> bool:
-    var tileset := _select_tileset()
+    var tileset: EnvironmentTileset = _select_tileset()
     if tileset == null:
         return false
-    var packed := tileset.pick_random_segment(_rng)
+    var packed: PackedScene = tileset.pick_random_segment(_rng)
     if packed == null:
         return false
-    var instance := packed.instantiate()
+    var instance: Node = packed.instantiate()
     if not instance:
         return false
     add_child(instance)
     if instance is Node2D:
         instance.position.x = _next_spawn_x
     _active_segments.append({"node": instance, "tileset": tileset})
-    var length := 960.0
+    var length: float = 960.0
     if instance is SegmentChunk:
         length = instance.segment_length
     _next_spawn_x += length
@@ -62,12 +62,12 @@ func _spawn_next_segment() -> bool:
 func _recycle_old_segments() -> void:
     if _player == null:
         return
-    var recycle_x := _player.global_position.x - recycle_margin
+    var recycle_x: float = _player.global_position.x - recycle_margin
     while _active_segments.size() > 0:
-        var entry := _active_segments[0]
-        var first: Node = entry.get("node")
-        var tileset: EnvironmentTileset = entry.get("tileset")
-        if first == null or not first is Node2D:
+        var entry: Dictionary = _active_segments[0]
+        var first: Node2D = entry.get("node") as Node2D
+        var tileset: EnvironmentTileset = entry.get("tileset") as EnvironmentTileset
+        if first == null:
             _active_segments.pop_front()
             continue
         if first.global_position.x + 1280.0 >= recycle_x:
@@ -78,7 +78,7 @@ func _recycle_old_segments() -> void:
 
 func _select_tileset() -> EnvironmentTileset:
     var available: Array[EnvironmentTileset] = []
-    var total_weight := 0.0
+    var total_weight: float = 0.0
     for tileset in tilesets:
         if tileset == null:
             continue
@@ -92,8 +92,8 @@ func _select_tileset() -> EnvironmentTileset:
             total_weight += max(tileset.weight, 0.001)
     if available.is_empty():
         return null
-    var pick := _rng.randf_range(0.0, total_weight)
-    var accumulator := 0.0
+    var pick: float = _rng.randf_range(0.0, total_weight)
+    var accumulator: float = 0.0
     for tileset in available:
         accumulator += max(tileset.weight, 0.001)
         if pick <= accumulator:

--- a/game/scripts/hazards/patrol_guard.gd
+++ b/game/scripts/hazards/patrol_guard.gd
@@ -8,7 +8,7 @@ class_name PatrolGuard
 @export var patrol_distance: float = 160.0
 @export var start_direction: int = 1
 
-var _origin: Vector2
+var _origin: Vector2 = Vector2.ZERO
 var _direction: int = 1
 
 func _ready() -> void:
@@ -24,10 +24,10 @@ func _physics_process(delta: float) -> void:
     velocity.x = patrol_speed * _direction
     velocity.y = 0.0
     move_and_slide()
-    var offset := global_position.x - _origin.x
+    var offset: float = global_position.x - _origin.x
     if abs(offset) >= patrol_distance:
         _direction *= -1
-        var clamped := clamp(offset, -patrol_distance, patrol_distance)
+        var clamped: float = clamp(offset, -patrol_distance, patrol_distance)
         global_position.x = _origin.x + clamped
 
 func get_heat_damage() -> float:

--- a/game/scripts/player.gd
+++ b/game/scripts/player.gd
@@ -25,13 +25,13 @@ var _is_sliding: bool = false
 var _is_jetpacking: bool = false
 var _shield_health: int = 0
 var _controls_enabled: bool = true
-var _hazard_cooldowns := {}
+var _hazard_cooldowns: Dictionary = {}
 
 const HAZARD_HIT_COOLDOWN := 0.5
 
 @onready var collision_shape: CollisionShape2D = $CollisionShape2D
-@onready var _base_shape := collision_shape.shape.duplicate(true) if collision_shape.shape else null
-@onready var _slide_shape := _make_slide_shape()
+@onready var _base_shape: Shape2D = collision_shape.shape.duplicate(true) if collision_shape.shape else null
+@onready var _slide_shape: RectangleShape2D = _make_slide_shape()
 @onready var _base_collision_offset: Vector2 = collision_shape.position
 
 func _ready() -> void:
@@ -145,7 +145,7 @@ func clear_shield(emit_signal: bool = true) -> void:
 func _make_slide_shape() -> RectangleShape2D:
     if _base_shape == null:
         return RectangleShape2D.new()
-    var slide_shape := RectangleShape2D.new()
+    var slide_shape: RectangleShape2D = RectangleShape2D.new()
     slide_shape.size = Vector2(_base_shape.size.x, _base_shape.size.y * 0.6)
     return slide_shape
 
@@ -164,14 +164,14 @@ func _update_hazard_cooldowns(delta: float) -> void:
         _hazard_cooldowns.erase(hazard)
 
 func _check_hazard_collisions() -> void:
-    var collisions := get_slide_collision_count()
+    var collisions: int = get_slide_collision_count()
     if collisions <= 0:
         return
     for index in range(collisions):
-        var collision := get_slide_collision(index)
+        var collision: KinematicCollision2D = get_slide_collision(index)
         if collision == null:
             continue
-        var collider := collision.get_collider()
+        var collider: Node = collision.get_collider()
         if collider == null:
             continue
         if not collider.is_in_group("hazard"):

--- a/game/scripts/powerups/powerup_manager.gd
+++ b/game/scripts/powerups/powerup_manager.gd
@@ -10,13 +10,13 @@ signal powerup_ready(powerup: PowerUp)
 @export var available_powerups: Array[PowerUp] = []
 @export var randomize_queue: bool = true
 
-var _player: RunnerPlayer
-var _world: Node
-var _active_powerup: PowerUp
+var _player: RunnerPlayer = null
+var _world: Node = null
+var _active_powerup: PowerUp = null
 var _active_timer: float = 0.0
-var _cooldowns := {}
-var _rng := RandomNumberGenerator.new()
-var _ready_state := {}
+var _cooldowns: Dictionary[StringName, float] = {}
+var _rng: RandomNumberGenerator = RandomNumberGenerator.new()
+var _ready_state: Dictionary[StringName, bool] = {}
 
 func _ready() -> void:
     if player_path != NodePath(""):
@@ -41,10 +41,10 @@ func _process(delta: float) -> void:
             trigger_random_powerup()
 
 func trigger_random_powerup() -> bool:
-    var ready := _get_ready_powerups()
+    var ready: Array[PowerUp] = _get_ready_powerups()
     if ready.is_empty():
         return false
-    var powerup := ready[0]
+    var powerup: PowerUp = ready[0]
     if randomize_queue and ready.size() > 1:
         powerup = ready[_rng.randi_range(0, ready.size() - 1)]
     return activate_powerup(powerup)
@@ -86,13 +86,14 @@ func _get_ready_powerups() -> Array[PowerUp]:
     return ready
 
 func _update_cooldowns(delta: float) -> void:
-    for id in _cooldowns.keys():
-        var previous_ready := _ready_state.get(id, false)
+    for key in _cooldowns.keys():
+        var id: StringName = key
+        var previous_ready: bool = bool(_ready_state.get(id, false))
         _cooldowns[id] = max(_cooldowns[id] - delta, 0.0)
-        var is_ready := _cooldowns[id] <= 0.0
+        var is_ready: bool = _cooldowns[id] <= 0.0
         _ready_state[id] = is_ready
         if is_ready and not previous_ready:
-            var powerup := _find_powerup(id)
+            var powerup: PowerUp = _find_powerup(id)
             if powerup:
                 powerup_ready.emit(powerup)
 
@@ -109,7 +110,7 @@ func set_world(world: Node) -> void:
     _world = world
 
 func grant_powerup(id: StringName) -> void:
-    var powerup := _find_powerup(id)
+    var powerup: PowerUp = _find_powerup(id)
     if not powerup:
         return
     _cooldowns[id] = 0.0

--- a/game/scripts/powerups/powerup_pickup.gd
+++ b/game/scripts/powerups/powerup_pickup.gd
@@ -7,7 +7,7 @@ signal collected(powerup_id: StringName)
 @export var auto_activate: bool = true
 @export var sprite_color: Color = Color(0.984314, 0.815686, 0.290196, 1)
 
-var _powerup_manager: PowerUpManager
+var _powerup_manager: PowerUpManager = null
 
 func _ready() -> void:
     connect("body_entered", Callable(self, "_on_body_entered"))
@@ -23,7 +23,7 @@ func _on_body_entered(body: Node) -> void:
     if _powerup_manager:
         if auto_activate:
             _powerup_manager.grant_powerup(powerup_id)
-            var powerup := _powerup_manager.get_powerup(powerup_id)
+            var powerup: PowerUp = _powerup_manager.get_powerup(powerup_id)
             if powerup:
                 _powerup_manager.activate_powerup(powerup)
         else:
@@ -35,7 +35,7 @@ func assign_manager(manager: PowerUpManager) -> void:
     _powerup_manager = manager
 
 func _find_powerup_manager() -> PowerUpManager:
-    var node := get_parent()
+    var node: Node = get_parent()
     while node:
         if node is PowerUpManager:
             return node

--- a/game/scripts/ui/hud.gd
+++ b/game/scripts/ui/hud.gd
@@ -14,10 +14,10 @@ class_name RunnerHUD
 @onready var _summary_heat_label: Label = %SummaryHeatLabel
 @onready var _retry_button: Button = %RetryButton
 
-var _world: RunnerWorld
-var _currency_base_modulate := Color(1, 1, 1, 1)
-var _distance_base_modulate := Color(1, 1, 1, 1)
-var _motorcade_base_modulate := Color(1, 1, 1, 1)
+var _world: RunnerWorld = null
+var _currency_base_modulate: Color = Color(1, 1, 1, 1)
+var _distance_base_modulate: Color = Color(1, 1, 1, 1)
+var _motorcade_base_modulate: Color = Color(1, 1, 1, 1)
 
 func _ready() -> void:
     if _currency_label:
@@ -92,13 +92,13 @@ func _on_motorcade_state_changed(active: bool, drain_rate: float) -> void:
 func _refresh_currency(total: float) -> void:
     if not _currency_label:
         return
-    var rounded := int(round(total))
+    var rounded: int = int(round(total))
     _currency_label.text = "Coin Bank: %d" % rounded
 
 func _refresh_distance(distance: float) -> void:
     if not _distance_label:
         return
-    var units := distance
+    var units: float = distance
     if distance_pixels_per_unit > 0.0:
         units = distance / distance_pixels_per_unit
     if show_decimal_distance:
@@ -123,7 +123,7 @@ func _update_motorcade_display(active: bool, drain_rate: float) -> void:
 func _flash_label(label: CanvasItem, highlight_color: Color) -> void:
     if label == null:
         return
-    var base_color := Color(1, 1, 1, 1)
+    var base_color: Color = Color(1, 1, 1, 1)
     if label == _currency_label:
         base_color = _currency_base_modulate
     elif label == _distance_label:
@@ -131,7 +131,7 @@ func _flash_label(label: CanvasItem, highlight_color: Color) -> void:
     elif label == _motorcade_label:
         base_color = _motorcade_base_modulate
     label.modulate = highlight_color
-    var tween := create_tween()
+    var tween: Tween = create_tween()
     tween.tween_property(label, "modulate", base_color, 0.35).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
 
 func _on_run_ended(distance: float, coins: float, heat: float, reason: String) -> void:
@@ -144,7 +144,7 @@ func _show_run_summary(distance: float, coins: float, heat: float, reason: Strin
     if _summary_reason_label:
         _summary_reason_label.text = reason
     if _summary_distance_label:
-        var units := distance
+        var units: float = distance
         if distance_pixels_per_unit > 0.0:
             units = distance / distance_pixels_per_unit
         if show_decimal_distance:
@@ -161,6 +161,6 @@ func _hide_run_summary() -> void:
         _summary_root.visible = false
 
 func _on_retry_pressed() -> void:
-    var tree := get_tree()
+    var tree: SceneTree = get_tree()
     if tree:
         tree.reload_current_scene()


### PR DESCRIPTION
## Summary
- add explicit type annotations across world, power-up, environment, and UI scripts to prevent Variant inference warnings
- type dictionaries, random number generators, and instantiated scenes so Godot loads resources without parse errors

## Testing
- not run (Godot engine not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cbeb44a2a8832fb7914c768d96c5a2